### PR TITLE
Fi fixes output file name

### DIFF
--- a/imod/protocols/protocol_applyTransformationMatrix.py
+++ b/imod/protocols/protocol_applyTransformationMatrix.py
@@ -72,7 +72,7 @@ class ProtImodApplyTransformationMatrix(EMProtocol, ProtTomoBase):
         tsId = ts.getTsId()
         extraPrefix = self._getExtraPath(tsId)
         path.makePath(extraPrefix)
-        utils.formatTransformFile(ts, os.path.join(extraPrefix, "%s.prexg" % tsId))
+        utils.formatTransformFile(ts, os.path.join(extraPrefix, ts.getFirstItem().parseFileName(extension=".prexg")))
 
     def generateOutputStackStep(self, tsObjId):
         outputInterpolatedSetOfTiltSeries = self.getOutputInterpolatedSetOfTiltSeries()
@@ -83,12 +83,12 @@ class ProtImodApplyTransformationMatrix(EMProtocol, ProtTomoBase):
         extraPrefix = self._getExtraPath(tsId)
 
         paramsAlignment = {
-            'input': ts.getFirstItem().getLocation()[1],
-            'output': os.path.join(extraPrefix, '%s.st' % tsId),
-            'xform': os.path.join(extraPrefix, "%s.prexg" % tsId),
+            'input': ts.getFirstItem().getFileName(),
+            'output': os.path.join(extraPrefix, ts.getFirstItem().parseFileName(suffix="_interpolated")),
+            'xform': os.path.join(extraPrefix, ts.getFirstItem().parseFileName(extension=".prexg")),
             'bin': int(self.binning.get()),
-            'imagebinned': 1.0}
-
+            'imagebinned': 1.0
+        }
         argsAlignment = "-input %(input)s " \
                         "-output %(output)s " \
                         "-xform %(xform)s " \
@@ -107,7 +107,7 @@ class ProtImodApplyTransformationMatrix(EMProtocol, ProtTomoBase):
         for index, tiltImage in enumerate(ts):
             newTi = tomoObj.TiltImage()
             newTi.copyInfo(tiltImage, copyId=True)
-            newTi.setLocation(index + 1, (os.path.join(extraPrefix, '%s.st' % tsId)))
+            newTi.setLocation(index + 1, (os.path.join(extraPrefix, tiltImage.parseFileName(suffix="_interpolated"))))
             if self.binning > 1:
                 newTi.setSamplingRate(tiltImage.getSamplingRate() * int(self.binning.get()))
             newTs.append(newTi)

--- a/imod/protocols/protocol_applyTransformationMatrix.py
+++ b/imod/protocols/protocol_applyTransformationMatrix.py
@@ -84,7 +84,7 @@ class ProtImodApplyTransformationMatrix(EMProtocol, ProtTomoBase):
 
         paramsAlignment = {
             'input': ts.getFirstItem().getFileName(),
-            'output': os.path.join(extraPrefix, ts.getFirstItem().parseFileName(suffix="_interpolated")),
+            'output': os.path.join(extraPrefix, ts.getFirstItem().parseFileName()),
             'xform': os.path.join(extraPrefix, ts.getFirstItem().parseFileName(extension=".prexg")),
             'bin': int(self.binning.get()),
             'imagebinned': 1.0
@@ -107,7 +107,7 @@ class ProtImodApplyTransformationMatrix(EMProtocol, ProtTomoBase):
         for index, tiltImage in enumerate(ts):
             newTi = tomoObj.TiltImage()
             newTi.copyInfo(tiltImage, copyId=True)
-            newTi.setLocation(index + 1, (os.path.join(extraPrefix, tiltImage.parseFileName(suffix="_interpolated"))))
+            newTi.setLocation(index + 1, (os.path.join(extraPrefix, tiltImage.parseFileName())))
             if self.binning > 1:
                 newTi.setSamplingRate(tiltImage.getSamplingRate() * int(self.binning.get()))
             newTs.append(newTi)

--- a/imod/protocols/protocol_ctfCorrecion.py
+++ b/imod/protocols/protocol_ctfCorrecion.py
@@ -86,10 +86,14 @@ class ProtImodCtfCorrection(EMProtocol, ProtTomoBase):
         tmpPrefix = self._getTmpPath(tsId)
         path.makePath(tmpPrefix)
         path.makePath(extraPrefix)
-        outputTltFileName = os.path.join(tmpPrefix, '%s.rawtlt' % tsId)
+
+        """Apply the transformation form the input tilt-series"""
+        outputTsFileName = os.path.join(tmpPrefix, ts.getFirstItem().parseFileName())
+        self.protCtfEstimation.get().inputSetOfTiltSeries.get()[tsObjId].applyTransform(outputTsFileName)
 
         """Generate angle file"""
-        ts.generateTltFile(outputTltFileName)
+        angleFilePath = os.path.join(tmpPrefix, ts.getFirstItem().parseFileName(extension=".tlt"))
+        self.protCtfEstimation.get().inputSetOfTiltSeries.get()[tsObjId].generateTltFile(angleFilePath)
 
     def ctfCorrection(self, tsObjId):
         """Run ctfphaseflip IMOD program"""
@@ -100,10 +104,12 @@ class ProtImodCtfCorrection(EMProtocol, ProtTomoBase):
         tmpPrefix = self._getTmpPath(tsId)
 
         paramsCtfPhaseFlip = {
-            'inputStack': os.path.join(self.protCtfEstimation.get()._getExtraPath(tsId), '%s_ctfEstimated.st' % tsId),
-            'angleFile': os.path.join(tmpPrefix, '%s.rawtlt' % tsId),
+            'inputStack': os.path.join(tmpPrefix, ts.getFirstItem().parseFileName()),
+            'angleFile': os.path.join(tmpPrefix, ts.getFirstItem().parseFileName(extension=".tlt")),
             'outputFileName': os.path.join(extraPrefix, '%s_ctfCorrected.st' % tsId),
-            'defocusFile': os.path.join(self.protCtfEstimation.get()._getExtraPath(tsId), '%s.defocus' % tsId),
+            'defocusFile': os.path.join(
+                self.protCtfEstimation.get()._getExtraPath(tsId),
+                self.protCtfEstimation.get().inputSetOfTiltSeries.get()[tsObjId].getFirstItem().parseFileName(extension=".defocus")),
             'voltage': self.inputSetOfTiltSeries.getAcquisition().getVoltage(),
             'sphericalAberration': self.inputSetOfTiltSeries.getAcquisition().getSphericalAberration(),
             'defocusTol': self.protCtfEstimation.get().defocusTol.get(),
@@ -139,7 +145,9 @@ class ProtImodCtfCorrection(EMProtocol, ProtTomoBase):
         for index, tiltImage in enumerate(ts):
             newTi = tomoObj.TiltImage()
             newTi.copyInfo(tiltImage, copyId=True)
-            newTi.setLocation(index + 1, (os.path.join(extraPrefix, '%s_ctfCorrected.st' % tsId)))
+            newTi.setLocation(index + 1,
+                              (os.path.join(extraPrefix, tiltImage.parseFileName(suffix="_ctfCorrected"))))
+            print(index + 1, os.path.join(extraPrefix, tiltImage.parseFileName(suffix="_ctfCorrected")))
             newTs.append(newTi)
 
         newTs.write(properties=False)

--- a/imod/protocols/protocol_ctfCorrecion.py
+++ b/imod/protocols/protocol_ctfCorrecion.py
@@ -106,7 +106,7 @@ class ProtImodCtfCorrection(EMProtocol, ProtTomoBase):
         paramsCtfPhaseFlip = {
             'inputStack': os.path.join(tmpPrefix, ts.getFirstItem().parseFileName()),
             'angleFile': os.path.join(tmpPrefix, ts.getFirstItem().parseFileName(extension=".tlt")),
-            'outputFileName': os.path.join(extraPrefix, '%s_ctfCorrected.st' % tsId),
+            'outputFileName': os.path.join(extraPrefix, ts.getFirstItem().parseFileName()),
             'defocusFile': os.path.join(
                 self.protCtfEstimation.get()._getExtraPath(tsId),
                 self.protCtfEstimation.get().inputSetOfTiltSeries.get()[tsObjId].getFirstItem().parseFileName(extension=".defocus")),
@@ -146,8 +146,7 @@ class ProtImodCtfCorrection(EMProtocol, ProtTomoBase):
             newTi = tomoObj.TiltImage()
             newTi.copyInfo(tiltImage, copyId=True)
             newTi.setLocation(index + 1,
-                              (os.path.join(extraPrefix, tiltImage.parseFileName(suffix="_ctfCorrected"))))
-            print(index + 1, os.path.join(extraPrefix, tiltImage.parseFileName(suffix="_ctfCorrected")))
+                              (os.path.join(extraPrefix, tiltImage.parseFileName())))
             newTs.append(newTi)
 
         newTs.write(properties=False)

--- a/imod/protocols/protocol_ctfEstimation.py
+++ b/imod/protocols/protocol_ctfEstimation.py
@@ -274,14 +274,15 @@ class ProtImodCtfEstimation(EMProtocol, ProtTomoBase):
         tmpPrefix = self._getTmpPath(tsId)
         path.makePath(tmpPrefix)
         path.makePath(extraPrefix)
-        outputTsFileName = os.path.join(extraPrefix, '%s_ctfEstimated.st' % tsId)
-        outputTltFileName = os.path.join(tmpPrefix, '%s.rawtlt' % tsId)
 
         """Apply the transformation form the input tilt-series"""
+        outputTsFileName = os.path.join(tmpPrefix, ts.getFirstItem().parseFileName(suffix="_ctfEstimated"))
         ts.applyTransform(outputTsFileName)
 
         """Generate angle file"""
-        ts.generateTltFile(outputTltFileName)
+        angleFilePath = os.path.join(tmpPrefix, ts.getFirstItem().parseFileName(extension=".tlt"))
+        ts.generateTltFile(angleFilePath)
+
 
     def ctfEstimation(self, tsObjId):
         """Run ctfplotter IMOD program"""
@@ -291,9 +292,9 @@ class ProtImodCtfEstimation(EMProtocol, ProtTomoBase):
         tmpPrefix = self._getTmpPath(tsId)
 
         paramsCtfPlotter = {
-            'inputStack': os.path.join(extraPrefix, '%s_ctfEstimated.st' % tsId),
-            'angleFile': os.path.join(tmpPrefix, '%s.rawtlt' % tsId),
-            'defocusFile': os.path.join(extraPrefix, '%s.defocus' % tsId),
+            'inputStack': os.path.join(tmpPrefix, ts.getFirstItem().parseFileName(suffix="_ctfEstimated")),
+            'angleFile': os.path.join(tmpPrefix, ts.getFirstItem().parseFileName(extension=".tlt")),
+            'defocusFile': os.path.join(extraPrefix, ts.getFirstItem().parseFileName(extension=".defocus")),
             'axisAngle': self.axisAngle.get(),
             'pixelSize': self.inputSetOfTiltSeries.get().getSamplingRate() / 10,
             'expectedDefocus': self.getExpectedDefocus(tsId),
@@ -376,7 +377,6 @@ class ProtImodCtfEstimation(EMProtocol, ProtTomoBase):
 
         ts = self.inputSetOfTiltSeries.get()[tsObjId]
         tsId = ts.getTsId()
-        extraPrefix = self._getExtraPath(tsId)
 
         newTs = tomoObj.TiltSeries(tsId=tsId)
         newTs.copyInfo(ts)
@@ -385,7 +385,9 @@ class ProtImodCtfEstimation(EMProtocol, ProtTomoBase):
         for index, tiltImage in enumerate(ts):
             newTi = tomoObj.TiltImage()
             newTi.copyInfo(tiltImage, copyId=True)
-            newTi.setLocation(index + 1, (os.path.join(extraPrefix, '%s_ctfEstimated.st' % tsId)))
+            newTi.setLocation(tiltImage.getLocation())
+            if tiltImage.hasTransform():
+                newTi.setTransform(tiltImage.getTransform())
             newTs.append(newTi)
 
         newTs.write(properties=False)

--- a/imod/protocols/protocol_ctfEstimation.py
+++ b/imod/protocols/protocol_ctfEstimation.py
@@ -276,7 +276,7 @@ class ProtImodCtfEstimation(EMProtocol, ProtTomoBase):
         path.makePath(extraPrefix)
 
         """Apply the transformation form the input tilt-series"""
-        outputTsFileName = os.path.join(tmpPrefix, ts.getFirstItem().parseFileName(suffix="_ctfEstimated"))
+        outputTsFileName = os.path.join(tmpPrefix, ts.getFirstItem().parseFileName())
         ts.applyTransform(outputTsFileName)
 
         """Generate angle file"""
@@ -292,7 +292,7 @@ class ProtImodCtfEstimation(EMProtocol, ProtTomoBase):
         tmpPrefix = self._getTmpPath(tsId)
 
         paramsCtfPlotter = {
-            'inputStack': os.path.join(tmpPrefix, ts.getFirstItem().parseFileName(suffix="_ctfEstimated")),
+            'inputStack': os.path.join(tmpPrefix, ts.getFirstItem().parseFileName()),
             'angleFile': os.path.join(tmpPrefix, ts.getFirstItem().parseFileName(extension=".tlt")),
             'defocusFile': os.path.join(extraPrefix, ts.getFirstItem().parseFileName(extension=".defocus")),
             'axisAngle': self.axisAngle.get(),

--- a/imod/protocols/protocol_etomo.py
+++ b/imod/protocols/protocol_etomo.py
@@ -201,18 +201,26 @@ class ProtImodEtomo(EMProtocol, ProtTomoBase):
             newTs.copyInfo(ts)
             outputPrealiSetOfTiltSeries.append(newTs)
 
+            ih = ImageHandler()
+
             for index, tiltImage in enumerate(ts):
                 newTi = tomoObj.TiltImage()
                 newTi.copyInfo(tiltImage, copyId=True)
-                newTi.setLocation(index + 1,
-                                  (os.path.join(extraPrefix, ts.getFirstItem().parseFileName(extension=".preali"))))
+                newTi.setLocation(
+                    index + 1,
+                    (os.path.join(extraPrefix, ts.getFirstItem().parseFileName(extension=".preali")))
+                    )
+                xPreali, _, _, _ = ih.getDimensions(newTi.getFileName()+":mrc")
+                newTi.setSamplingRate(self.getPixSizeFromDimensions(xPreali))
+                print(newTi.getLocation())
                 newTs.append(newTi)
 
-            ih = ImageHandler()
-            xPreali, _, _, _ = ih.getDimensions(newTs.getFirstItem().getFileName()+":mrc")
-            newTs.setDim(ih.getDimensions(newTs.getFirstItem().getFileName()+":mrc"))
+            x, y, z, _ = ih.getDimensions(newTs.getFirstItem().getFileName()+":mrc")
+            newTs.setDim((x, y, z))
+
             newTs.write(properties=False)
 
+            xPreali, _, _, _ = ih.getDimensions(newTs.getFirstItem().getFileName()+":mrc")
             outputPrealiSetOfTiltSeries.setSamplingRate(self.getPixSizeFromDimensions(xPreali))
             outputPrealiSetOfTiltSeries.update(newTs)
             outputPrealiSetOfTiltSeries.write()

--- a/imod/protocols/protocol_etomo.py
+++ b/imod/protocols/protocol_etomo.py
@@ -108,19 +108,19 @@ class ProtImodEtomo(EMProtocol, ProtTomoBase):
 
         """Apply transformation matrices and remove excluded views"""
         if self.excludeList.get() == '':
-            outputTsFileName = os.path.join(extraPrefix, "%s.st" % tsId)
-            angleFilePath = os.path.join(extraPrefix, "%s.rawtlt" % tsId)
 
             """Apply the transformation form the input tilt-series"""
+            outputTsFileName = os.path.join(extraPrefix, ts.getFirstItem().parseFileName())
             ts.applyTransform(outputTsFileName)
 
             """Generate angle file"""
+            angleFilePath = os.path.join(extraPrefix, ts.getFirstItem().parseFileName(extension=".tlt"))
             ts.generateTltFile(angleFilePath)
 
         else:
-            interpolatedTsFileName = os.path.join(tmpPrefix, "%s.st" % tsId)
-            outputTsFileName = os.path.join(extraPrefix, "%s.st" % tsId)
-            angleFilePath = os.path.join(extraPrefix, "%s.rawtlt" % tsId)
+            interpolatedTsFileName = os.path.join(tmpPrefix, ts.getFirstItem().parseFileName())
+            outputTsFileName = os.path.join(extraPrefix, ts.getFirstItem().parseFileName())
+            angleFilePath = os.path.join(extraPrefix, ts.getFirstItem().parseFileName(extension=".tlt"))
 
             """Apply the transformation form the input tilt-series and generate a new ts object"""
             ts.applyTransform(interpolatedTsFileName)
@@ -147,9 +147,7 @@ class ProtImodEtomo(EMProtocol, ProtTomoBase):
                          excludeList=excludeList)
 
         """Generate etomo config file"""
-        workingFolder = self._getExtraPath(tsId)
-
-        args = '-name %s ' % tsId
+        args = '-name %s ' % ts.getFirstItem().parseFileName(extension="")
         args += '-gold %0.3f ' % self.markersDiameter
 
         # Imod use the pixel size in NM
@@ -160,10 +158,11 @@ class ProtImodEtomo(EMProtocol, ProtTomoBase):
         args += '-rotation %0.3f ' % self.rotationAngle
         args += '-userawtlt'
 
-        Plugin.runImod(self, 'copytomocoms', args, cwd=workingFolder)
+        Plugin.runImod(self, 'copytomocoms', args, cwd=extraPrefix)
 
-        edfFn = os.path.join(workingFolder, '%s.edf' % tsId)
-        minTilt = min(utils.formatAngleList(os.path.join(extraPrefix, "%s.rawtlt" % tsId)))
+        edfFn = os.path.join(extraPrefix, '%s.edf' % tsId)
+        minTilt = min(utils.formatAngleList(os.path.join(extraPrefix,
+                                                         ts.getFirstItem().parseFileName(extension=".tlt"))))
         self._writeEtomoEdf(edfFn,
                             {
                                 'date': pw.utils.prettyTime(),

--- a/imod/protocols/protocol_etomo.py
+++ b/imod/protocols/protocol_etomo.py
@@ -209,18 +209,16 @@ class ProtImodEtomo(EMProtocol, ProtTomoBase):
                 newTi.setLocation(
                     index + 1,
                     (os.path.join(extraPrefix, ts.getFirstItem().parseFileName(extension=".preali")))
-                    )
+                )
                 xPreali, _, _, _ = ih.getDimensions(newTi.getFileName()+":mrc")
                 newTi.setSamplingRate(self.getPixSizeFromDimensions(xPreali))
-                print(newTi.getLocation())
                 newTs.append(newTi)
 
-            x, y, z, _ = ih.getDimensions(newTs.getFirstItem().getFileName()+":mrc")
-            newTs.setDim((x, y, z))
+            xPreali, yPreali, zPreali, _ = ih.getDimensions(newTs.getFirstItem().getFileName()+":mrc")
+            newTs.setDim((xPreali, yPreali, zPreali))
 
             newTs.write(properties=False)
 
-            xPreali, _, _, _ = ih.getDimensions(newTs.getFirstItem().getFileName()+":mrc")
             outputPrealiSetOfTiltSeries.setSamplingRate(self.getPixSizeFromDimensions(xPreali))
             outputPrealiSetOfTiltSeries.update(newTs)
             outputPrealiSetOfTiltSeries.write()
@@ -238,20 +236,26 @@ class ProtImodEtomo(EMProtocol, ProtTomoBase):
             newTs.copyInfo(ts)
             outputAliSetOfTiltSeries.append(newTs)
 
+            ih = ImageHandler()
+
             tltFilePath = os.path.join(extraPrefix, ts.getFirstItem().parseFileName(suffix='_fid', extension=".tlt"))
             tltList = utils.formatAngleList(tltFilePath)
 
             for index, tiltImage in enumerate(ts):
                 newTi = tomoObj.TiltImage()
                 newTi.copyInfo(tiltImage, copyId=True)
-                newTi.setLocation(index + 1, (os.path.join(extraPrefix,
-                                                           ts.getFirstItem().parseFileName(extension=".ali"))))
+                newTi.setLocation(
+                    index + 1,
+                    (os.path.join(extraPrefix, ts.getFirstItem().parseFileName(extension=".ali")))
+                )
                 newTi.setTiltAngle(float(tltList[index]))
+                xAli, _, _, _ = ih.getDimensions(newTi.getFileName()+":mrc")
+                newTi.setSamplingRate(self.getPixSizeFromDimensions(xAli))
                 newTs.append(newTi)
 
-            ih = ImageHandler()
-            xAli, yAli, _, _ = ih.getDimensions(newTs.getFirstItem().getFileName() + ":mrc")
-            newTs.setDim(ih.getDimensions(newTs.getFirstItem().getFileName() + ":mrc"))
+            xAli, yAli, zAli, _ = ih.getDimensions(newTs.getFirstItem().getFileName() + ":mrc")
+            newTs.setDim((xPreali, yPreali, zPreali))
+
             newTs.write(properties=False)
 
             outputAliSetOfTiltSeries.setSamplingRate(self.getPixSizeFromDimensions(xAli))

--- a/imod/protocols/protocol_fiducialAlignment.py
+++ b/imod/protocols/protocol_fiducialAlignment.py
@@ -142,7 +142,7 @@ class ProtImodFiducialAlignment(EMProtocol, ProtTomoBase):
 
         """"Link to input tilt-series (needed for fiducial model viewer)"""
         # TODO: there is no need to come from a prealigned stack
-        inputTS = os.path.join(extraPrefix, "%s_preali.st" % tsId)
+        inputTS = os.path.join(extraPrefix, ts.getFirstItem().parseFileName(suffix="_preali"))
         if ts.getFirstItem().hasTransform():
             path.copyFile(outputTsFileName, inputTS)
 

--- a/imod/protocols/protocol_fiducialAlignment.py
+++ b/imod/protocols/protocol_fiducialAlignment.py
@@ -142,7 +142,7 @@ class ProtImodFiducialAlignment(EMProtocol, ProtTomoBase):
 
         """"Link to input tilt-series (needed for fiducial model viewer)"""
         # TODO: there is no need to come from a prealigned stack
-        inputTS = os.path.join(extraPrefix, ts.getFirstItem().parseFileName(suffix="_preali"))
+        inputTS = os.path.join(extraPrefix, ts.getFirstItem().parseFileName())
         if ts.getFirstItem().hasTransform():
             path.copyFile(outputTsFileName, inputTS)
 
@@ -475,7 +475,7 @@ class ProtImodFiducialAlignment(EMProtocol, ProtTomoBase):
 
         paramsAlignment = {
             'input': os.path.join(tmpPrefix, ts.getFirstItem().parseFileName()),
-            'output': os.path.join(extraPrefix, ts.getFirstItem().parseFileName(suffix="_fidali")),
+            'output': os.path.join(extraPrefix, ts.getFirstItem().parseFileName()),
             'xform': os.path.join(extraPrefix, ts.getFirstItem().parseFileName(suffix="_fid", extension=".xf")),
             'bin': int(self.binning.get()),
             'imagebinned': 1.0}
@@ -502,7 +502,7 @@ class ProtImodFiducialAlignment(EMProtocol, ProtTomoBase):
         for index, ti in enumerate(ts):
             newTi = tomoObj.TiltImage()
             newTi.copyInfo(ti, copyId=True)
-            newTi.setLocation(index + 1, os.path.join(extraPrefix, ti.parseFileName(suffix="_fidali")))
+            newTi.setLocation(index + 1, os.path.join(extraPrefix, ti.parseFileName()))
             newTi.setTiltAngle(float(tltList[index]))
             if self.binning > 1:
                 newTi.setSamplingRate(ti.getSamplingRate() * int(self.binning.get()))

--- a/imod/protocols/protocol_fiducialAlignment.py
+++ b/imod/protocols/protocol_fiducialAlignment.py
@@ -131,16 +131,17 @@ class ProtImodFiducialAlignment(EMProtocol, ProtTomoBase):
         tmpPrefix = self._getTmpPath(tsId)
         path.makePath(tmpPrefix)
         path.makePath(extraPrefix)
-        outputTsFileName = os.path.join(tmpPrefix, "%s.st" % tsId)
 
         """Apply the transformation form the input tilt-series"""
+        outputTsFileName = os.path.join(tmpPrefix, ts.getFirstItem().parseFileName())
         ts.applyTransform(outputTsFileName)
 
         """Generate angle file"""
-        angleFilePath = os.path.join(tmpPrefix, "%s.rawtlt" % tsId)
+        angleFilePath = os.path.join(tmpPrefix, ts.getFirstItem().parseFileExtension(extension=".tlt"))
         ts.generateTltFile(angleFilePath)
 
         """"Link to input tilt-series (needed for fiducial model viewer)"""
+        # TODO: there is no need to come from a prealigned stack
         inputTS = os.path.join(extraPrefix, "%s_preali.st" % tsId)
         if ts.getFirstItem().hasTransform():
             path.copyFile(outputTsFileName, inputTS)
@@ -154,7 +155,7 @@ class ProtImodFiducialAlignment(EMProtocol, ProtTomoBase):
         extraPrefix = self._getExtraPath(tsId)
         tmpPrefix = self._getTmpPath(tsId)
         paramsDict = {
-            'imageFile': os.path.join(tmpPrefix, '%s.st' % tsId),
+            'imageFile': os.path.join(tmpPrefix, ts.getFirstItem().parseFileName()),
             'inputSeedModel': os.path.join(extraPrefix, '%s.seed' % tsId),
             'outputModel': os.path.join(extraPrefix, '%s_gaps.fid' % tsId),
             'tiltFile': os.path.join(tmpPrefix, '%s.rawtlt' % tsId),

--- a/imod/protocols/protocol_fiducialAlignment.py
+++ b/imod/protocols/protocol_fiducialAlignment.py
@@ -415,14 +415,9 @@ class ProtImodFiducialAlignment(EMProtocol, ProtTomoBase):
         Plugin.runImod(self, 'model2point', argsNoGapPoint2Model % paramsNoGapPoint2Model)
 
     def computeOutputStackStep(self, tsObjId):
-        outputSetOfTiltSeries = self.getOutputSetOfTiltSeries()
         ts = self.inputSetOfTiltSeries.get()[tsObjId]
         tsId = ts.getTsId()
         extraPrefix = self._getExtraPath(tsId)
-
-        newTs = tomoObj.TiltSeries(tsId=tsId)
-        newTs.copyInfo(ts)
-        outputSetOfTiltSeries.append(newTs)
 
         tltFilePath = os.path.join(extraPrefix,
                                    ts.getFirstItem().parseFileName(suffix="_interpolated", extension=".tlt"))
@@ -433,10 +428,15 @@ class ProtImodFiducialAlignment(EMProtocol, ProtTomoBase):
                                             ts.getFirstItem().parseFileName(suffix="_fid", extension=".xf"))
         newTransformationMatricesList = utils.formatTransformationMatrix(transformationMatricesFilePath)
 
+        outputSetOfTiltSeries = self.getOutputSetOfTiltSeries()
+        newTs = tomoObj.TiltSeries(tsId=tsId)
+        newTs.copyInfo(ts)
+        outputSetOfTiltSeries.append(newTs)
+
         for index, ti in enumerate(ts):
             newTi = tomoObj.TiltImage()
             newTi.copyInfo(ti, copyId=True)
-            newTi.setLocation(index + 1, ti.parseFileName())
+            newTi.setLocation(ti.getLocation())
             newTi.setTiltAngle(float(tltList[index]))
 
             if ti.hasTransform():

--- a/imod/protocols/protocol_fiducialAlignment.py
+++ b/imod/protocols/protocol_fiducialAlignment.py
@@ -137,7 +137,7 @@ class ProtImodFiducialAlignment(EMProtocol, ProtTomoBase):
         ts.applyTransform(outputTsFileName)
 
         """Generate angle file"""
-        angleFilePath = os.path.join(tmpPrefix, ts.getFirstItem().parseFileExtension(extension=".tlt"))
+        angleFilePath = os.path.join(tmpPrefix, ts.getFirstItem().parseFileName(extension=".tlt"))
         ts.generateTltFile(angleFilePath)
 
         """"Link to input tilt-series (needed for fiducial model viewer)"""
@@ -154,15 +154,17 @@ class ProtImodFiducialAlignment(EMProtocol, ProtTomoBase):
         tsId = ts.getTsId()
         extraPrefix = self._getExtraPath(tsId)
         tmpPrefix = self._getTmpPath(tsId)
+
         paramsDict = {
             'imageFile': os.path.join(tmpPrefix, ts.getFirstItem().parseFileName()),
-            'inputSeedModel': os.path.join(extraPrefix, '%s.seed' % tsId),
-            'outputModel': os.path.join(extraPrefix, '%s_gaps.fid' % tsId),
-            'tiltFile': os.path.join(tmpPrefix, '%s.rawtlt' % tsId),
+            'inputSeedModel': os.path.join(extraPrefix, ts.getFirstItem().parseFileName(extension=".seed")),
+            'outputModel': os.path.join(extraPrefix, ts.getFirstItem().parseFileName(suffix="_gaps", extension=".fid")),
+            'tiltFile': os.path.join(tmpPrefix, ts.getFirstItem().parseFileName(extension=".tlt")),
             'rotationAngle': self.rotationAngle.get(),
             'fiducialDiameter': self.fiducialDiameter.get()
         }
-        self.translateTrackCom(tsId, paramsDict)
+
+        self.translateTrackCom(ts, paramsDict)
 
     def generateFiducialSeedStep(self, tsObjId):
         ts = self.inputSetOfTiltSeries.get()[tsObjId]
@@ -170,7 +172,8 @@ class ProtImodFiducialAlignment(EMProtocol, ProtTomoBase):
         extraPrefix = self._getExtraPath(tsId)
 
         paramsAutofidseed = {
-            'trackCommandFile': os.path.join(extraPrefix, '%s_track.com' % tsId),
+            'trackCommandFile': os.path.join(extraPrefix,
+                                             ts.getFirstItem().parseFileName(suffix="_track", extension=".com")),
             'minSpacing': 0.85,
             'peakStorageFraction': 1.0,
             'RotationAngle': self.rotationAngle.get(),
@@ -182,6 +185,7 @@ class ProtImodFiducialAlignment(EMProtocol, ProtTomoBase):
                           "-TargetNumberOfBeads %(targetNumberOfBeads)d "
         if self.twoSurfaces.get() == 0:
             argsAutofidseed += " -TwoSurfaces"
+
         Plugin.runImod(self, 'autofidseed', argsAutofidseed % paramsAutofidseed)
 
         autofidseedDirPath = os.path.join(self._getExtraPath(tsId), "autofidseed.dir")
@@ -195,11 +199,11 @@ class ProtImodFiducialAlignment(EMProtocol, ProtTomoBase):
         extraPrefix = self._getExtraPath(tsId)
         tmpPrefix = self._getTmpPath(tsId)
         paramsBeadtrack = {
-            'inputSeedModel': os.path.join(extraPrefix, '%s.seed' % tsId),
-            'outputModel': os.path.join(extraPrefix, '%s_gaps.fid' % tsId),
-            'imageFile': os.path.join(tmpPrefix, '%s.st' % tsId),
+            'inputSeedModel': os.path.join(extraPrefix, ts.getFirstItem().parseFileName(extension=".seed")),
+            'outputModel': os.path.join(extraPrefix, ts.getFirstItem().parseFileName(suffix="_gaps", extension=".fid")),
+            'imageFile': os.path.join(tmpPrefix, ts.getFirstItem().parseFileName()),
             'imagesAreBinned': 1,
-            'tiltFile': os.path.join(tmpPrefix, '%s.rawtlt' % tsId),
+            'tiltFile': os.path.join(tmpPrefix, ts.getFirstItem().parseFileName(extension=".tlt")),
             'tiltDefaultGrouping': 7,
             'magDefaultGrouping': 5,
             'rotDefaultGrouping': 1,
@@ -268,17 +272,23 @@ class ProtImodFiducialAlignment(EMProtocol, ProtTomoBase):
         extraPrefix = self._getExtraPath(tsId)
         tmpPrefix = self._getTmpPath(tsId)
         paramsTiltAlign = {
-            'modelFile': os.path.join(extraPrefix, '%s_gaps.fid' % tsId),
-            'imageFile': os.path.join(tmpPrefix, '%s.st' % tsId),
+            'modelFile': os.path.join(extraPrefix, ts.getFirstItem().parseFileName(suffix="_gaps", extension=".fid")),
+            'imageFile': os.path.join(tmpPrefix, ts.getFirstItem().parseFileName()),
             'imagesAreBinned': 1,
-            'outputModelFile': os.path.join(extraPrefix, '%s_fidxyz.mod' % tsId),
-            'outputResidualFile': os.path.join(extraPrefix, '%s_resid.txt' % tsId),
-            'outputFidXYZFile': os.path.join(extraPrefix, '%s_fid.xyz' % tsId),
-            'outputTiltFile': os.path.join(extraPrefix, '%s_interpolated.tlt' % tsId),
-            'outputTransformFile': os.path.join(extraPrefix, '%s_fid.xf' % tsId),
-            'outputFilledInModel': os.path.join(extraPrefix, '%s_noGaps.fid' % tsId),
+            'outputModelFile': os.path.join(extraPrefix,
+                                            ts.getFirstItem().parseFileName(suffix="_fidxyz", extension=".mod")),
+            'outputResidualFile': os.path.join(extraPrefix,
+                                               ts.getFirstItem().parseFileName(suffix="_resid", extension=".txt")),
+            'outputFidXYZFile': os.path.join(extraPrefix,
+                                             ts.getFirstItem().parseFileName(suffix="_fid", extension=".xyz")),
+            'outputTiltFile': os.path.join(extraPrefix,
+                                           ts.getFirstItem().parseFileName(suffix="_interpolated", extension=".tlt")),
+            'outputTransformFile': os.path.join(extraPrefix,
+                                                ts.getFirstItem().parseFileName(suffix="_fid", extension=".xf")),
+            'outputFilledInModel': os.path.join(extraPrefix,
+                                                ts.getFirstItem().parseFileName(suffix="_noGaps", extension=".fid")),
             'rotationAngle': self.rotationAngle.get(),
-            'tiltFile': os.path.join(tmpPrefix, '%s.rawtlt' % tsId),
+            'tiltFile': os.path.join(tmpPrefix, ts.getFirstItem().parseFileName(extension=".tlt")),
             'angleOffset': 0.0,
             'rotOption': 1,
             'rotDefaultGrouping': 5,
@@ -303,7 +313,8 @@ class ProtImodFiducialAlignment(EMProtocol, ProtTomoBase):
             'axisZShift': 0.0,
             'shiftZFromOriginal': 1,
             'localAlignments': 0,
-            'outputLocalFile': os.path.join(extraPrefix, '%s_local.xf' % tsId),
+            'outputLocalFile': os.path.join(extraPrefix,
+                                            ts.getFirstItem().parseFileName(suffix="_local", extension=".xf")),
             'targetPatchSizeXandY': '700,700',
             'minSizeOrOverlapXandY': '0.5,0.5',
             'minFidsTotalAndEachSurface': '8,3',
@@ -382,43 +393,50 @@ class ProtImodFiducialAlignment(EMProtocol, ProtTomoBase):
         extraPrefix = self._getExtraPath(tsId)
 
         paramsGapPoint2Model = {
-            'inputFile': os.path.join(extraPrefix, '%s_gaps.fid' % tsId),
-            'outputFile': os.path.join(extraPrefix, '%s_gaps_fid.txt' % tsId)
+            'inputFile': os.path.join(extraPrefix,
+                                      ts.getFirstItem().parseFileName(suffix="_gaps", extension=".fid")),
+            'outputFile': os.path.join(extraPrefix,
+                                       ts.getFirstItem().parseFileName(suffix="_gaps_fid", extension=".txt"))
         }
         argsGapPoint2Model = "-InputFile %(inputFile)s " \
                              "-OutputFile %(outputFile)s"
+
         Plugin.runImod(self, 'model2point', argsGapPoint2Model % paramsGapPoint2Model)
 
         paramsNoGapPoint2Model = {
-            'inputFile': os.path.join(extraPrefix, '%s_noGaps.fid' % tsId),
-            'outputFile': os.path.join(extraPrefix, '%s_noGaps_fid.txt' % tsId)
+            'inputFile': os.path.join(extraPrefix,
+                                      ts.getFirstItem().parseFileName(suffix="_noGaps", extension=".fid")),
+            'outputFile': os.path.join(extraPrefix,
+                                       ts.getFirstItem().parseFileName(suffix="_noGaps_fid", extension=".txt"))
         }
         argsNoGapPoint2Model = "-InputFile %(inputFile)s " \
                                "-OutputFile %(outputFile)s"
+
         Plugin.runImod(self, 'model2point', argsNoGapPoint2Model % paramsNoGapPoint2Model)
 
     def computeOutputStackStep(self, tsObjId):
         outputSetOfTiltSeries = self.getOutputSetOfTiltSeries()
-
         ts = self.inputSetOfTiltSeries.get()[tsObjId]
         tsId = ts.getTsId()
+        extraPrefix = self._getExtraPath(tsId)
 
         newTs = tomoObj.TiltSeries(tsId=tsId)
         newTs.copyInfo(ts)
         outputSetOfTiltSeries.append(newTs)
 
-        tltFileName = tsId + "_interpolated.tlt"
-        tltFilePath = os.path.join(self._getExtraPath(tsId), tltFileName)
+        tltFilePath = os.path.join(extraPrefix,
+                                   ts.getFirstItem().parseFileName(suffix="_interpolated", extension=".tlt"))
         tltList = utils.formatAngleList(tltFilePath)
 
-        transformationMatricesFile = tsId + "_fid.xf"
-        transformationMatricesFilePath = os.path.join(self._getExtraPath(tsId), transformationMatricesFile)
+        transformationMatricesFilePath = os.path.join(
+                                            extraPrefix,
+                                            ts.getFirstItem().parseFileName(suffix="_fid", extension=".xf"))
         newTransformationMatricesList = utils.formatTransformationMatrix(transformationMatricesFilePath)
 
         for index, ti in enumerate(ts):
             newTi = tomoObj.TiltImage()
             newTi.copyInfo(ti, copyId=True)
-            newTi.setLocation(index + 1, ti.getLocation()[1])
+            newTi.setLocation(index + 1, ti.parseFileName())
             newTi.setTiltAngle(float(tltList[index]))
 
             if ti.hasTransform():
@@ -436,9 +454,11 @@ class ProtImodFiducialAlignment(EMProtocol, ProtTomoBase):
                 newTransformArray = np.array(newTransform)
                 transform.setMatrix(newTransformArray)
                 newTi.setTransform(transform)
+
             newTs.append(newTi)
 
         newTs.write(properties=False)
+
         outputSetOfTiltSeries.update(newTs)
         outputSetOfTiltSeries.write()
         self._store()
@@ -453,9 +473,9 @@ class ProtImodFiducialAlignment(EMProtocol, ProtTomoBase):
         tmpPrefix = self._getTmpPath(tsId)
 
         paramsAlignment = {
-            'input': os.path.join(tmpPrefix, '%s.st' % tsId),
-            'output': os.path.join(extraPrefix, '%s_fidali.st' % tsId),
-            'xform': os.path.join(extraPrefix, "%s_fid.xf" % tsId),
+            'input': os.path.join(tmpPrefix, ts.getFirstItem().parseFileName()),
+            'output': os.path.join(extraPrefix, ts.getFirstItem().parseFileName(suffix="_fidali")),
+            'xform': os.path.join(extraPrefix, ts.getFirstItem().parseFileName(suffix="_fid", extension=".xf")),
             'bin': int(self.binning.get()),
             'imagebinned': 1.0}
         argsAlignment = "-input %(input)s " \
@@ -463,14 +483,16 @@ class ProtImodFiducialAlignment(EMProtocol, ProtTomoBase):
                         "-xform %(xform)s " \
                         "-bin %(bin)d " \
                         "-imagebinned %(imagebinned)s"
+
         Plugin.runImod(self, 'newstack', argsAlignment % paramsAlignment)
 
         newTs = tomoObj.TiltSeries(tsId=tsId)
         newTs.copyInfo(ts)
         outputInterpolatedSetOfTiltSeries.append(newTs)
 
-        tltFileName = tsId + "_interpolated.tlt"
-        tltFilePath = os.path.join(extraPrefix, tltFileName)
+        tltFilePath = os.path.join(extraPrefix,
+                                   ts.getFirstItem().parseFileName(suffix="_interpolated", extension=".tlt"))
+
         tltList = utils.formatAngleList(tltFilePath)
 
         if self.binning > 1:
@@ -479,7 +501,7 @@ class ProtImodFiducialAlignment(EMProtocol, ProtTomoBase):
         for index, ti in enumerate(ts):
             newTi = tomoObj.TiltImage()
             newTi.copyInfo(ti, copyId=True)
-            newTi.setLocation(index + 1, os.path.join(extraPrefix, '%s_fidali.st' % tsId))
+            newTi.setLocation(index + 1, os.path.join(extraPrefix, ti.parseFileName(suffix="_fidali")))
             newTi.setTiltAngle(float(tltList[index]))
             if self.binning > 1:
                 newTi.setSamplingRate(ti.getSamplingRate() * int(self.binning.get()))
@@ -498,21 +520,19 @@ class ProtImodFiducialAlignment(EMProtocol, ProtTomoBase):
     def computeOutputModelsStep(self, tsObjId):
         ts = self.inputSetOfTiltSeries.get()[tsObjId]
         tsId = ts.getTsId()
+        extraPrefix = self._getExtraPath(tsId)
 
         """Create the output set of landmark models with gaps"""
         outputSetOfLandmarkModelsGaps = self.getOutputFiducialModelGaps()
 
-        fiducialModelGapFileName = tsId + "_gaps.fid"
-        fiducialModelGapPath = os.path.join(self._getExtraPath(tsId), fiducialModelGapFileName)
+        fiducialModelGapPath = os.path.join(extraPrefix,
+                                            ts.getFirstItem().parseFileName(suffix="_gaps", extension=".fid"))
 
-        landmarkModelGapsFileName = tsId + "_gaps.sfid"
-        landmarkModelGapsFilePath = os.path.join(self._getExtraPath(tsId), landmarkModelGapsFileName)
-
-        landmarkModelGapsResidFileName = '%s_resid.txt' % tsId
-        landmarkModelGapsResidPath = os.path.join(self._getExtraPath(tsId), landmarkModelGapsResidFileName)
+        landmarkModelGapsResidPath = os.path.join(extraPrefix,
+                                                  ts.getFirstItem().parseFileName(suffix="_resid", extension=".txt"))
         fiducialGapResidList = utils.formatFiducialResidList(landmarkModelGapsResidPath)
 
-        landmarkModelGaps = LandmarkModel(tsId, landmarkModelGapsFilePath, fiducialModelGapPath)
+        landmarkModelGaps = LandmarkModel(tsId, landmarkModelGapsResidPath, fiducialModelGapPath)
 
         prevTiltIm = 0
         chainId = 0
@@ -534,18 +554,18 @@ class ProtImodFiducialAlignment(EMProtocol, ProtTomoBase):
         """Create the output set of landmark models with no gaps"""
         outputSetOfLandmarkModelsNoGaps = self.getOutputFiducialModelNoGaps()
 
-        fiducialNoGapFileName = tsId + "_noGaps_fid.txt"
-        fiducialNoGapFilePath = os.path.join(self._getExtraPath(tsId), fiducialNoGapFileName)
+        fiducialNoGapFilePath = os.path.join(extraPrefix,
+                                             ts.getFirstItem().parseFileName(suffix="_noGaps_fid", extension=".txt"))
         fiducialNoGapList = utils.formatFiducialList(fiducialNoGapFilePath)
 
-        fiducialModelNoGapFileName = tsId + "_noGaps.fid"
-        fiducialModelNoGapPath = os.path.join(self._getExtraPath(tsId), fiducialModelNoGapFileName)
+        fiducialModelNoGapPath = os.path.join(extraPrefix,
+                                              ts.getFirstItem().parseFileName(suffix="_noGaps", extension=".fid"))
 
-        landmarkModelNoGapsFileName = tsId + "_noGaps.sfid"
-        landmarkModelNoGapsFilePath = os.path.join(self._getExtraPath(tsId), landmarkModelNoGapsFileName)
+        landmarkModelNoGapsFilePath = os.path.join(extraPrefix,
+                                                   ts.getFirstItem().parseFileName(suffix="_noGaps", extension=".sfid"))
 
-        landmarkModelNoGapsResidFileName = '%s_resid.txt' % tsId
-        landmarkModelNoGapsResidPath = os.path.join(self._getExtraPath(tsId), landmarkModelNoGapsResidFileName)
+        landmarkModelNoGapsResidPath = os.path.join(extraPrefix,
+                                                    ts.getFirstItem().parseFileName(suffix="_resid", extension=".txt"))
         fiducialNoGapsResidList = utils.formatFiducialResidList(landmarkModelNoGapsResidPath)
 
         landmarkModelNoGaps = LandmarkModel(tsId, landmarkModelNoGapsFilePath, fiducialModelNoGapPath)
@@ -580,8 +600,9 @@ class ProtImodFiducialAlignment(EMProtocol, ProtTomoBase):
         """Create the output set of coordinates 3D from the fiducials in the tilt series"""
         outputSetOfCoordinates3D = self.getOutputSetOfCoordinates3Ds()
 
-        coordFileName = tsId + "_fid.xyz"
-        coordFilePath = os.path.join(self._getExtraPath(tsId), coordFileName)
+        coordFilePath = os.path.join(extraPrefix,
+                                     ts.getFirstItem().parseFileName(suffix="_fid", extension=".xyz"))
+
         xDim = ts.getFirstItem().getXDim()
         yDim = ts.getFirstItem().getYDim()
         coordList = utils.format3DCoordinatesList(coordFilePath, xDim, yDim)
@@ -607,9 +628,13 @@ class ProtImodFiducialAlignment(EMProtocol, ProtTomoBase):
         self._store()
 
     # --------------------------- UTILS functions ----------------------------
-    def translateTrackCom(self, tsId, paramsDict):
-        trackFileName = tsId + "_track.com"
-        trackFilePath = os.path.join(self._getExtraPath(tsId), trackFileName)
+    def translateTrackCom(self, ts, paramsDict):
+        tsId = ts.getTsId()
+        extraPrefix = self._getExtraPath(tsId)
+
+        trackFilePath = os.path.join(extraPrefix,
+                                     ts.getFirstItem().parseFileName(suffix="_track", extension=".com"))
+
         template = """# Command file for running BEADTRACK
 #
 ####CreatedVersion####4.9.12

--- a/imod/protocols/protocol_fiducialAlignment.py
+++ b/imod/protocols/protocol_fiducialAlignment.py
@@ -461,6 +461,7 @@ class ProtImodFiducialAlignment(EMProtocol, ProtTomoBase):
 
         outputSetOfTiltSeries.update(newTs)
         outputSetOfTiltSeries.write()
+
         self._store()
 
     def computeOutputInterpolatedStackStep(self, tsObjId):

--- a/imod/protocols/protocol_tsNormalization.py
+++ b/imod/protocols/protocol_tsNormalization.py
@@ -186,7 +186,7 @@ class ProtImodTSNormalization(EMProtocol, ProtTomoBase):
 
         paramsNewstack = {
             'input': os.path.join(tmpPrefix, ts.getFirstItem().parseFileName()),
-            'output': os.path.join(extraPrefix, ts.getFirstItem().parseFileName("_norm")),
+            'output': os.path.join(extraPrefix, ts.getFirstItem().parseFileName(suffix="_norm")),
             'bin': int(self.binning.get()),
             'imagebinned': 1.0,
         }
@@ -227,7 +227,7 @@ class ProtImodTSNormalization(EMProtocol, ProtTomoBase):
         for index, tiltImage in enumerate(ts):
             newTi = tomoObj.TiltImage()
             newTi.copyInfo(tiltImage, copyId=True)
-            newTi.setLocation(index + 1, (os.path.join(extraPrefix, tiltImage.parseFileName("_norm"))))
+            newTi.setLocation(index + 1, (os.path.join(extraPrefix, tiltImage.parseFileName(suffix="_norm"))))
             if self.binning > 1:
                 newTi.setSamplingRate(tiltImage.getSamplingRate() * int(self.binning.get()))
             newTs.append(newTi)

--- a/imod/protocols/protocol_tsNormalization.py
+++ b/imod/protocols/protocol_tsNormalization.py
@@ -234,7 +234,6 @@ class ProtImodTSNormalization(EMProtocol, ProtTomoBase):
 
         ih = ImageHandler()
         x, y, z, _ = ih.getDimensions(newTs.getFirstItem().getFileName())
-        print(newTs.getFirstItem().getFileName(), "AAAAAAAAAAAAAAAAAAAAAAAAAAAaa")
         newTs.setDim((x, y, z))
 
         newTs.write(properties=False)

--- a/imod/protocols/protocol_tsNormalization.py
+++ b/imod/protocols/protocol_tsNormalization.py
@@ -170,9 +170,9 @@ class ProtImodTSNormalization(EMProtocol, ProtTomoBase):
         tmpPrefix = self._getTmpPath(tsId)
         path.makePath(tmpPrefix)
         path.makePath(extraPrefix)
-        outputTsFileName = os.path.join(tmpPrefix, "%s.st" % tsId)
 
         """Apply the transformation form the input tilt-series"""
+        outputTsFileName = os.path.join(tmpPrefix, ts.getFirstItem().parseFileName())
         ts.applyTransform(outputTsFileName)
 
     def generateOutputStackStep(self, tsObjId):
@@ -187,8 +187,8 @@ class ProtImodTSNormalization(EMProtocol, ProtTomoBase):
         tmpPrefix = self._getTmpPath(tsId)
 
         paramsNewstack = {
-            'input': os.path.join(tmpPrefix, '%s.st' % tsId),
-            'output': os.path.join(extraPrefix, '%s.st' % tsId),
+            'input': os.path.join(tmpPrefix, ts.getFirstItem().parseFileName()),
+            'output': os.path.join(extraPrefix, ts.getFirstItem().parseFileName()),
             'bin': int(self.binning.get()),
             'imagebinned': 1.0,
         }
@@ -225,13 +225,13 @@ class ProtImodTSNormalization(EMProtocol, ProtTomoBase):
         for index, tiltImage in enumerate(ts):
             newTi = tomoObj.TiltImage()
             newTi.copyInfo(tiltImage, copyId=True)
-            newTi.setLocation(index + 1, (os.path.join(extraPrefix, '%s.st' % tsId)))
+            newTi.setLocation(index + 1, ts.getFirstItem().parseFileName())
             if self.binning > 1:
                 newTi.setSamplingRate(tiltImage.getSamplingRate() * int(self.binning.get()))
             newTs.append(newTi)
 
         ih = ImageHandler()
-        x, y, z, _ = ih.getDimensions(newTs.getFirstItem().getFileName())
+        x, y, z, _ = ih.getDimensions(newTs.getFirstItem().parseFileName())
         newTs.setDim((x, y, z))
         newTs.write()
 

--- a/imod/protocols/protocol_xCorrPrealignment.py
+++ b/imod/protocols/protocol_xCorrPrealignment.py
@@ -181,7 +181,6 @@ class ProtImodXcorrPrealignment(EMProtocol, ProtTomoBase):
 
         """Generate output tilt series"""
         outputSetOfTiltSeries = self.getOutputSetOfTiltSeries()
-        tsId = ts.getTsId()
         alignmentMatrix = utils.formatTransformationMatrix(
             os.path.join(extraPrefix, ts.getFirstItem().parseFileName(extension=".prexf")))
         newTs = tomoObj.TiltSeries(tsId=tsId)

--- a/imod/protocols/protocol_xCorrPrealignment.py
+++ b/imod/protocols/protocol_xCorrPrealignment.py
@@ -214,7 +214,7 @@ class ProtImodXcorrPrealignment(EMProtocol, ProtTomoBase):
 
         paramsAlignment = {
             'input': os.path.join(tmpPrefix, ts.getFirstItem().parseFileName()),
-            'output': os.path.join(extraPrefix, ts.getFirstItem().parseFileName(suffix="_preali")),
+            'output': os.path.join(extraPrefix, ts.getFirstItem().parseFileName()),
             'xform': os.path.join(extraPrefix, ts.getFirstItem().parseFileName(extension=".prexg")),
             'bin': int(self.binning.get()),
             'imagebinned': 1.0
@@ -237,7 +237,7 @@ class ProtImodXcorrPrealignment(EMProtocol, ProtTomoBase):
         for index, tiltImage in enumerate(ts):
             newTi = tomoObj.TiltImage()
             newTi.copyInfo(tiltImage, copyId=True)
-            newTi.setLocation(index + 1, (os.path.join(extraPrefix, tiltImage.parseFileName(suffix="_preali"))))
+            newTi.setLocation(index + 1, (os.path.join(extraPrefix, tiltImage.parseFileName())))
             if self.binning > 1:
                 newTi.setSamplingRate(tiltImage.getSamplingRate() * int(self.binning.get()))
             newTs.append(newTi)

--- a/imod/protocols/protocol_xCorrPrealignment.py
+++ b/imod/protocols/protocol_xCorrPrealignment.py
@@ -198,6 +198,7 @@ class ProtImodXcorrPrealignment(EMProtocol, ProtTomoBase):
             newTs.append(newTi)
 
         newTs.write(properties=False)
+
         outputSetOfTiltSeries.update(newTs)
         outputSetOfTiltSeries.write()
 

--- a/imod/protocols/protocol_xCorrPrealignment.py
+++ b/imod/protocols/protocol_xCorrPrealignment.py
@@ -224,6 +224,7 @@ class ProtImodXcorrPrealignment(EMProtocol, ProtTomoBase):
                         "-xform %(xform)s " \
                         "-bin %(bin)d " \
                         "-imagebinned %(imagebinned)s"
+
         Plugin.runImod(self, 'newstack', argsAlignment % paramsAlignment)
 
         newTs = tomoObj.TiltSeries(tsId=tsId)

--- a/imod/protocols/protocol_xCorrPrealignment.py
+++ b/imod/protocols/protocol_xCorrPrealignment.py
@@ -236,7 +236,7 @@ class ProtImodXcorrPrealignment(EMProtocol, ProtTomoBase):
         for index, tiltImage in enumerate(ts):
             newTi = tomoObj.TiltImage()
             newTi.copyInfo(tiltImage, copyId=True)
-            newTi.setLocation(index + 1, (os.path.join(extraPrefix, tiltImage.parseFileName("_preali"))))
+            newTi.setLocation(index + 1, (os.path.join(extraPrefix, tiltImage.parseFileName(suffix="_preali"))))
             if self.binning > 1:
                 newTi.setSamplingRate(tiltImage.getSamplingRate() * int(self.binning.get()))
             newTs.append(newTi)

--- a/imod/protocols/protocol_xCorrPrealignment.py
+++ b/imod/protocols/protocol_xCorrPrealignment.py
@@ -141,7 +141,7 @@ class ProtImodXcorrPrealignment(EMProtocol, ProtTomoBase):
         ts.applyTransform(outputTsFileName)
 
         """Generate angle file"""
-        angleFilePath = os.path.join(tmpPrefix, ts.getFirstItem().parseFileExtension(extension=".tlt"))
+        angleFilePath = os.path.join(tmpPrefix, ts.getFirstItem().parseFileName(extension=".tlt"))
         ts.generateTltFile(angleFilePath)
 
     def computeXcorrStep(self, tsObjId):
@@ -153,8 +153,8 @@ class ProtImodXcorrPrealignment(EMProtocol, ProtTomoBase):
 
         paramsXcorr = {
             'input': os.path.join(tmpPrefix, ts.getFirstItem().parseFileName()),
-            'output': os.path.join(extraPrefix, ts.getFirstItem().parseFileExtension(extension=".prexf")),
-            'tiltfile': os.path.join(tmpPrefix, ts.getFirstItem().parseFileExtension(extension=".tlt")),
+            'output': os.path.join(extraPrefix, ts.getFirstItem().parseFileName(extension=".prexf")),
+            'tiltfile': os.path.join(tmpPrefix, ts.getFirstItem().parseFileName(extension=".tlt")),
             'rotationAngle': self.rotationAngle.get(),
             'filterSigma1': self.filterSigma1.get(),
             'filterSigma2': self.filterSigma2.get(),
@@ -172,8 +172,8 @@ class ProtImodXcorrPrealignment(EMProtocol, ProtTomoBase):
         Plugin.runImod(self, 'tiltxcorr', argsXcorr % paramsXcorr)
 
         paramsXftoxg = {
-            'input': os.path.join(extraPrefix, ts.getFirstItem().parseFileExtension(extension=".prexf")),
-            'goutput': os.path.join(extraPrefix, ts.getFirstItem().parseFileExtension(extension=".prexg")),
+            'input': os.path.join(extraPrefix, ts.getFirstItem().parseFileName(extension=".prexf")),
+            'goutput': os.path.join(extraPrefix, ts.getFirstItem().parseFileName(extension=".prexg")),
         }
         argsXftoxg = "-input %(input)s " \
                      "-goutput %(goutput)s"
@@ -183,7 +183,7 @@ class ProtImodXcorrPrealignment(EMProtocol, ProtTomoBase):
         outputSetOfTiltSeries = self.getOutputSetOfTiltSeries()
         tsId = ts.getTsId()
         alignmentMatrix = utils.formatTransformationMatrix(
-            os.path.join(extraPrefix, ts.getFirstItem().parseFileExtension(extension=".prexf")))
+            os.path.join(extraPrefix, ts.getFirstItem().parseFileName(extension=".prexf")))
         newTs = tomoObj.TiltSeries(tsId=tsId)
         newTs.copyInfo(ts)
         outputSetOfTiltSeries.append(newTs)
@@ -215,7 +215,7 @@ class ProtImodXcorrPrealignment(EMProtocol, ProtTomoBase):
         paramsAlignment = {
             'input': os.path.join(tmpPrefix, ts.getFirstItem().parseFileName()),
             'output': os.path.join(extraPrefix, ts.getFirstItem().parseFileName(suffix="_preali")),
-            'xform': os.path.join(extraPrefix, ts.getFirstItem().parseFileExtension(extension=".prexg")),
+            'xform': os.path.join(extraPrefix, ts.getFirstItem().parseFileName(extension=".prexg")),
             'bin': int(self.binning.get()),
             'imagebinned': 1.0
         }

--- a/imod/protocols/protocol_xCorrPrealignment.py
+++ b/imod/protocols/protocol_xCorrPrealignment.py
@@ -135,7 +135,9 @@ class ProtImodXcorrPrealignment(EMProtocol, ProtTomoBase):
         tmpPrefix = self._getTmpPath(tsId)
         path.makePath(tmpPrefix)
         path.makePath(extraPrefix)
-        outputTsFileName = os.path.join(tmpPrefix, "%s.st" % tsId)
+
+        fileName = ts.getFirstItem().parseFileName()
+        outputTsFileName = os.path.join(tmpPrefix, fileName)
 
         """Apply the transformation form the input tilt-series"""
         ts.applyTransform(outputTsFileName)
@@ -186,6 +188,7 @@ class ProtImodXcorrPrealignment(EMProtocol, ProtTomoBase):
         newTs = tomoObj.TiltSeries(tsId=tsId)
         newTs.copyInfo(ts)
         outputSetOfTiltSeries.append(newTs)
+
         for index, tiltImage in enumerate(ts):
             newTi = tomoObj.TiltImage()
             newTi.copyInfo(tiltImage, copyId=True)
@@ -194,9 +197,11 @@ class ProtImodXcorrPrealignment(EMProtocol, ProtTomoBase):
             transform.setMatrix(alignmentMatrix[:, :, index])
             newTi.setTransform(transform)
             newTs.append(newTi)
+
         newTs.write()
         outputSetOfTiltSeries.update(newTs)
         outputSetOfTiltSeries.write()
+
         self._store()
 
     def computeInterpolatedStackStep(self, tsObjId):
@@ -232,7 +237,7 @@ class ProtImodXcorrPrealignment(EMProtocol, ProtTomoBase):
         for index, tiltImage in enumerate(ts):
             newTi = tomoObj.TiltImage()
             newTi.copyInfo(tiltImage, copyId=True)
-            newTi.setLocation(index + 1, (os.path.join(extraPrefix, '%s_preali.st' % tsId)))
+            newTi.setLocation(index + 1, (os.path.join(extraPrefix, tiltImage.parseFileName("_preali"))))
             if self.binning > 1:
                 newTi.setSamplingRate(tiltImage.getSamplingRate() * int(self.binning.get()))
             newTs.append(newTi)

--- a/imod/protocols/protocol_xCorrPrealignment.py
+++ b/imod/protocols/protocol_xCorrPrealignment.py
@@ -136,14 +136,12 @@ class ProtImodXcorrPrealignment(EMProtocol, ProtTomoBase):
         path.makePath(tmpPrefix)
         path.makePath(extraPrefix)
 
-        fileName = ts.getFirstItem().parseFileName()
-        outputTsFileName = os.path.join(tmpPrefix, fileName)
-
         """Apply the transformation form the input tilt-series"""
+        outputTsFileName = os.path.join(tmpPrefix, ts.getFirstItem().parseFileName())
         ts.applyTransform(outputTsFileName)
 
         """Generate angle file"""
-        angleFilePath = os.path.join(tmpPrefix, "%s.rawtlt" % tsId)
+        angleFilePath = os.path.join(tmpPrefix, "%s.tlt" % ts.getFirstItem().parseFileExtension(extension=".tlt"))
         ts.generateTltFile(angleFilePath)
 
     def computeXcorrStep(self, tsObjId):

--- a/imod/protocols/protocol_xCorrPrealignment.py
+++ b/imod/protocols/protocol_xCorrPrealignment.py
@@ -141,7 +141,7 @@ class ProtImodXcorrPrealignment(EMProtocol, ProtTomoBase):
         ts.applyTransform(outputTsFileName)
 
         """Generate angle file"""
-        angleFilePath = os.path.join(tmpPrefix, "%s.tlt" % ts.getFirstItem().parseFileExtension(extension=".tlt"))
+        angleFilePath = os.path.join(tmpPrefix, ts.getFirstItem().parseFileExtension(extension=".tlt"))
         ts.generateTltFile(angleFilePath)
 
     def computeXcorrStep(self, tsObjId):
@@ -152,9 +152,9 @@ class ProtImodXcorrPrealignment(EMProtocol, ProtTomoBase):
         tmpPrefix = self._getTmpPath(tsId)
 
         paramsXcorr = {
-            'input': os.path.join(tmpPrefix, '%s.st' % tsId),
-            'output': os.path.join(extraPrefix, '%s.prexf' % tsId),
-            'tiltfile': os.path.join(tmpPrefix, '%s.rawtlt' % tsId),
+            'input': os.path.join(tmpPrefix, ts.getFirstItem().parseFileName()),
+            'output': os.path.join(extraPrefix, ts.getFirstItem().parseFileExtension(extension=".prexf")),
+            'tiltfile': os.path.join(tmpPrefix, ts.getFirstItem().parseFileExtension(extension=".tlt")),
             'rotationAngle': self.rotationAngle.get(),
             'filterSigma1': self.filterSigma1.get(),
             'filterSigma2': self.filterSigma2.get(),
@@ -172,8 +172,8 @@ class ProtImodXcorrPrealignment(EMProtocol, ProtTomoBase):
         Plugin.runImod(self, 'tiltxcorr', argsXcorr % paramsXcorr)
 
         paramsXftoxg = {
-            'input': os.path.join(extraPrefix, '%s.prexf' % tsId),
-            'goutput': os.path.join(extraPrefix, '%s.prexg' % tsId),
+            'input': os.path.join(extraPrefix, ts.getFirstItem().parseFileExtension(extension=".prexf")),
+            'goutput': os.path.join(extraPrefix, ts.getFirstItem().parseFileExtension(extension=".prexg")),
         }
         argsXftoxg = "-input %(input)s " \
                      "-goutput %(goutput)s"
@@ -182,7 +182,8 @@ class ProtImodXcorrPrealignment(EMProtocol, ProtTomoBase):
         """Generate output tilt series"""
         outputSetOfTiltSeries = self.getOutputSetOfTiltSeries()
         tsId = ts.getTsId()
-        alignmentMatrix = utils.formatTransformationMatrix(self._getExtraPath('%s/%s.prexg' % (tsId, tsId)))
+        alignmentMatrix = utils.formatTransformationMatrix(
+            os.path.join(extraPrefix, ts.getFirstItem().parseFileExtension(extension=".prexf")))
         newTs = tomoObj.TiltSeries(tsId=tsId)
         newTs.copyInfo(ts)
         outputSetOfTiltSeries.append(newTs)
@@ -212,9 +213,9 @@ class ProtImodXcorrPrealignment(EMProtocol, ProtTomoBase):
         tmpPrefix = self._getTmpPath(tsId)
 
         paramsAlignment = {
-            'input': os.path.join(tmpPrefix, '%s.st' % tsId),
-            'output': os.path.join(extraPrefix, '%s_preali.st' % tsId),
-            'xform': os.path.join(extraPrefix, "%s.prexg" % tsId),
+            'input': os.path.join(tmpPrefix, ts.getFirstItem().parseFileName()),
+            'output': os.path.join(extraPrefix, ts.getFirstItem().parseFileName(suffix="_preali")),
+            'xform': os.path.join(extraPrefix, ts.getFirstItem().parseFileExtension(extension=".prexg")),
             'bin': int(self.binning.get()),
             'imagebinned': 1.0
         }

--- a/imod/utils.py
+++ b/imod/utils.py
@@ -81,7 +81,8 @@ def formatFiducialList(fiducialFilePath):
     with open(fiducialFilePath) as f:
         fiducialText = f.read().splitlines()
         for line in fiducialText:
-            vector = line.split()
+            # Fix IMOD bug: columns merge in coordinates exceed 3 digits
+            vector = line.replace('-', ' -').split()
             vector = [round(float(i)) for i in vector]
             fiducialList.append(vector)
     return fiducialList
@@ -96,7 +97,8 @@ def formatFiducialResidList(fiducialFilePath):
     with open(fiducialFilePath) as f:
         fiducialText = f.read().splitlines()
         for line in fiducialText[1:]:
-            vector = line.split()
+            # Fix IMOD bug: columns merge in coordinates exceed 3 digits
+            vector = line.replace('-', ' -').split()
             fiducialResidList.append([round(float(vector[0])),
                                       round(float(vector[1])),
                                       int(vector[2]),

--- a/imod/utils.py
+++ b/imod/utils.py
@@ -82,6 +82,7 @@ def formatFiducialList(fiducialFilePath):
         fiducialText = f.read().splitlines()
         for line in fiducialText:
             vector = line.split()
+            vector = [round(float(i)) for i in vector]
             fiducialList.append(vector)
     return fiducialList
 

--- a/imod/utils.py
+++ b/imod/utils.py
@@ -99,9 +99,9 @@ def formatFiducialResidList(fiducialFilePath):
             vector = line.split()
             fiducialResidList.append([round(float(vector[0])),
                                       round(float(vector[1])),
-                                      vector[2],
-                                      vector[3],
-                                      vector[4]])
+                                      int(vector[2]),
+                                      float(vector[3]),
+                                      float(vector[4])])
     return fiducialResidList
 
 


### PR DESCRIPTION
This PR includes:

- Output filename fixes in all protocols
- Sqlite properties fixes in all protocols that output a set of tilt-series
- Refactor in etomo, fiducial alignment, tomo reconstruction, and tilt-series normalization
- Fixes in output landmark models in fiducial alignment
- Fixes in output set properties in etomo 
- Fixes in formating fiducial list methods in utils