### PR TITLE
Fi fixes ouput stream

### DIFF
--- a/imod/protocols/protocol_ctfCorrecion.py
+++ b/imod/protocols/protocol_ctfCorrecion.py
@@ -156,10 +156,13 @@ class ProtImodCtfCorrection(EMProtocol, ProtTomoBase):
 
     # --------------------------- UTILS functions ----------------------------
     def getOutputCtfCorrectedSetOfTiltSeries(self):
-        if not hasattr(self, "outputCtfCorrectedSetOfTiltSeries"):
+        if hasattr(self, "outputCtfEstimatedSetOfTiltSeries"):
+            self.outputCtfEstimatedSetOfTiltSeries.enableAppend()
+        else:
             outputCtfCorrectedSetOfTiltSeries = self._createSetOfTiltSeries(suffix='CtfCorrected')
             outputCtfCorrectedSetOfTiltSeries.copyInfo(self.inputSetOfTiltSeries)
             outputCtfCorrectedSetOfTiltSeries.setDim(self.inputSetOfTiltSeries.getDim())
+            outputCtfCorrectedSetOfTiltSeries.setStreamState(pw.object.Set.STREAM_OPEN)
             self._defineOutputs(outputCtfCorrectedSetOfTiltSeries=outputCtfCorrectedSetOfTiltSeries)
             self._defineSourceRelation(self.inputSetOfTiltSeries, outputCtfCorrectedSetOfTiltSeries)
         return self.outputCtfCorrectedSetOfTiltSeries

--- a/imod/protocols/protocol_ctfCorrecion.py
+++ b/imod/protocols/protocol_ctfCorrecion.py
@@ -27,6 +27,7 @@
 import os
 import numpy as np
 import imod.utils as utils
+import pyworkflow as pw
 import pyworkflow.protocol.params as params
 import pyworkflow.utils.path as path
 from pwem.protocols import EMProtocol

--- a/imod/protocols/protocol_ctfEstimation.py
+++ b/imod/protocols/protocol_ctfEstimation.py
@@ -406,6 +406,7 @@ class ProtImodCtfEstimation(EMProtocol, ProtTomoBase):
             outputCtfEstimatedSetOfTiltSeries = self._createSetOfTiltSeries(suffix='CtfEstimated')
             outputCtfEstimatedSetOfTiltSeries.copyInfo(self.inputSetOfTiltSeries.get())
             outputCtfEstimatedSetOfTiltSeries.setDim(self.inputSetOfTiltSeries.get().getDim())
+            outputCtfEstimatedSetOfTiltSeries.setStreamState(pw.object.Set.STREAM_OPEN)
             self._defineOutputs(outputCtfEstimatedSetOfTiltSeries=outputCtfEstimatedSetOfTiltSeries)
             self._defineSourceRelation(self.inputSetOfTiltSeries, outputCtfEstimatedSetOfTiltSeries)
         return self.outputCtfEstimatedSetOfTiltSeries

--- a/imod/protocols/protocol_ctfEstimation.py
+++ b/imod/protocols/protocol_ctfEstimation.py
@@ -281,7 +281,6 @@ class ProtImodCtfEstimation(EMProtocol, ProtTomoBase):
         angleFilePath = os.path.join(tmpPrefix, ts.getFirstItem().parseFileName(extension=".tlt"))
         ts.generateTltFile(angleFilePath)
 
-
     def ctfEstimation(self, tsObjId):
         """Run ctfplotter IMOD program"""
         ts = self.inputSetOfTiltSeries.get()[tsObjId]

--- a/imod/protocols/protocol_ctfEstimation.py
+++ b/imod/protocols/protocol_ctfEstimation.py
@@ -25,15 +25,12 @@
 # **************************************************************************
 
 import os
-import numpy as np
-import imod.utils as utils
 import pyworkflow as pw
 import pyworkflow.protocol.params as params
 import pyworkflow.utils.path as path
 from pwem.protocols import EMProtocol
 import tomo.objects as tomoObj
 from tomo.protocols import ProtTomoBase
-from pwem.emlib.image import ImageHandler
 from imod import Plugin
 
 

--- a/imod/protocols/protocol_ctfEstimation.py
+++ b/imod/protocols/protocol_ctfEstimation.py
@@ -27,6 +27,7 @@
 import os
 import numpy as np
 import imod.utils as utils
+import pyworkflow as pw
 import pyworkflow.protocol.params as params
 import pyworkflow.utils.path as path
 from pwem.protocols import EMProtocol

--- a/imod/protocols/protocol_etomo.py
+++ b/imod/protocols/protocol_etomo.py
@@ -104,11 +104,12 @@ class ProtImodEtomo(EMProtocol, ProtTomoBase):
         path.makePath(tmpPrefix)
         path.makePath(extraPrefix)
 
+        outputTsFileName = os.path.join(extraPrefix, ts.getFirstItem().parseFileName())
+
         """Apply transformation matrices and remove excluded views"""
         if self.excludeList.get() == '':
 
             """Apply the transformation form the input tilt-series"""
-            outputTsFileName = os.path.join(extraPrefix, ts.getFirstItem().parseFileName())
             ts.applyTransform(outputTsFileName)
 
             """Generate angle file"""
@@ -117,7 +118,6 @@ class ProtImodEtomo(EMProtocol, ProtTomoBase):
 
         else:
             interpolatedTsFileName = os.path.join(tmpPrefix, ts.getFirstItem().parseFileName())
-            outputTsFileName = os.path.join(extraPrefix, ts.getFirstItem().parseFileName())
             angleFilePath = os.path.join(extraPrefix, ts.getFirstItem().parseFileName(extension=".rawtlt"))
 
             """Apply the transformation form the input tilt-series and generate a new ts object"""
@@ -140,7 +140,7 @@ class ProtImodEtomo(EMProtocol, ProtTomoBase):
             interpolatedTs.write()
 
             """Write a new stack discarding excluded tilts"""
-            excludeList = map(int, self.excludeList.get().split())
+            excludeList = [int(i) for i in self.excludeList.get().split()]
             tiList = [ti.clone() for ti in interpolatedTs]
             tiList.sort(key=lambda ti: ti.getTiltAngle())
 

--- a/imod/protocols/protocol_etomo.py
+++ b/imod/protocols/protocol_etomo.py
@@ -31,10 +31,8 @@ import os
 import pyworkflow as pw
 import pyworkflow.protocol.params as params
 import pyworkflow.utils.path as path
-from pyworkflow.mapper import SqliteDb
 from pwem.protocols import EMProtocol
 import tomo.objects as tomoObj
-from tomo.objects import Tomogram
 from tomo.protocols import ProtTomoBase
 from tomo.convert import writeTiStack
 from imod import Plugin

--- a/imod/protocols/protocol_etomo.py
+++ b/imod/protocols/protocol_etomo.py
@@ -66,7 +66,7 @@ class ProtImodEtomo(EMProtocol, ProtTomoBase):
                       default='',
                       label='Exclusion list',
                       help='Provide tilt images IDs (usually starting at 1) that you want to exclude from the '
-                           'processing.')
+                           'processing separated by blank spaces.')
 
         form.addParam('binning',
                       params.IntParam,
@@ -123,9 +123,14 @@ class ProtImodEtomo(EMProtocol, ProtTomoBase):
             """Apply the transformation form the input tilt-series and generate a new ts object"""
             ts.applyTransform(interpolatedTsFileName)
 
+            interpolatedSetOfTiltSeries = self._createSetOfTiltSeries(suffix='Interpolated')
+            interpolatedSetOfTiltSeries.copyInfo(self.inputTiltSeries.get())
+            interpolatedSetOfTiltSeries.setDim(self.inputTiltSeries.get().getDim())
+
             interpolatedTs = tomoObj.TiltSeries(tsId=tsId)
             interpolatedTs.copyInfo(ts)
-            outputSetOfTiltSeries.append(interpolatedTs)
+
+            interpolatedSetOfTiltSeries.append(interpolatedTs)
 
             for index, tiltImage in enumerate(ts):
                 newTi = tomoObj.TiltImage()

--- a/imod/protocols/protocol_fiducialAlignment.py
+++ b/imod/protocols/protocol_fiducialAlignment.py
@@ -701,7 +701,9 @@ $if (-e ./savework) ./savework
             f.write(template % paramsDict)
 
     def getOutputSetOfTiltSeries(self):
-        if not hasattr(self, "outputSetOfTiltSeries"):
+        if hasattr(self, "outputSetOfTiltSeries"):
+            self.outputSetOfTiltSeries.enableAppend()
+        else:
             outputSetOfTiltSeries = self._createSetOfTiltSeries()
             outputSetOfTiltSeries.copyInfo(self.inputSetOfTiltSeries.get())
             outputSetOfTiltSeries.setDim(self.inputSetOfTiltSeries.get().getDim())
@@ -711,7 +713,9 @@ $if (-e ./savework) ./savework
         return self.outputSetOfTiltSeries
 
     def getOutputInterpolatedSetOfTiltSeries(self):
-        if not hasattr(self, "outputInterpolatedSetOfTiltSeries"):
+        if hasattr(self, "outputInterpolatedSetOfTiltSeries"):
+            self.outputInterpolatedSetOfTiltSeries.enableAppend()
+        else:
             outputInterpolatedSetOfTiltSeries = self._createSetOfTiltSeries(suffix='Interpolated')
             outputInterpolatedSetOfTiltSeries.copyInfo(self.inputSetOfTiltSeries.get())
             outputInterpolatedSetOfTiltSeries.setDim(self.inputSetOfTiltSeries.get().getDim())
@@ -725,7 +729,9 @@ $if (-e ./savework) ./savework
         return self.outputInterpolatedSetOfTiltSeries
 
     def getOutputFiducialModelGaps(self):
-        if not hasattr(self, "outputFiducialModelGaps"):
+        if hasattr(self, "outputFiducialModelGaps"):
+            self.outputFiducialModelGaps.enableAppend()
+        else:
             outputFiducialModelGaps = self._createSetOfLandmarkModels(suffix='Gaps')
             outputFiducialModelGaps.copyInfo(self.inputSetOfTiltSeries.get())
             outputFiducialModelGaps.setStreamState(pw.object.Set.STREAM_OPEN)
@@ -734,7 +740,9 @@ $if (-e ./savework) ./savework
         return self.outputFiducialModelGaps
 
     def getOutputFiducialModelNoGaps(self):
-        if not hasattr(self, "outputFiducialModelNoGaps"):
+        if hasattr(self, "outputFiducialModelNoGaps"):
+            self.outputFiducialModelNoGaps.enableAppend()
+        else:
             outputFiducialModelNoGaps = self._createSetOfLandmarkModels(suffix='NoGaps')
             outputFiducialModelNoGaps.copyInfo(self.inputSetOfTiltSeries.get())
             outputFiducialModelNoGaps.setStreamState(pw.object.Set.STREAM_OPEN)
@@ -743,7 +751,9 @@ $if (-e ./savework) ./savework
         return self.outputFiducialModelNoGaps
 
     def getOutputSetOfCoordinates3Ds(self):
-        if not hasattr(self, "outputSetOfCoordinates3D"):
+        if hasattr(self, "outputSetOfCoordinates3D"):
+            self.outputSetOfCoordinates3D.enableAppend()
+        else:
             outputSetOfCoordinates3D = self._createSetOfCoordinates3D(volSet=self.getOutputSetOfTiltSeries(),
                                                                       suffix='LandmarkModel')
             outputSetOfCoordinates3D.setSamplingRate(self.inputSetOfTiltSeries.get().getSamplingRate())

--- a/imod/protocols/protocol_fiducialAlignment.py
+++ b/imod/protocols/protocol_fiducialAlignment.py
@@ -30,13 +30,11 @@ import imod.utils as utils
 import pyworkflow as pw
 import pyworkflow.protocol.params as params
 import pyworkflow.utils.path as path
-from pwem.emlib.image import ImageHandler
 from pwem.objects import Transform
 from pwem.protocols import EMProtocol
 import tomo.objects as tomoObj
 from tomo.objects import LandmarkModel
 from tomo.protocols import ProtTomoBase
-from tomo.convert import writeTiStack
 from imod import Plugin
 from pwem.emlib.image import ImageHandler
 

--- a/imod/protocols/protocol_tomoNormalization.py
+++ b/imod/protocols/protocol_tomoNormalization.py
@@ -243,12 +243,15 @@ class ProtImodTomoNormalization(EMProtocol, ProtTomoBase):
 
     # --------------------------- UTILS functions ----------------------------
     def getOutputNormalizedSetOfTomograms(self):
-        if not hasattr(self, "outputNormalizedSetOfTomograms"):
+        if hasattr(self, "outputNormalizedSetOfTomograms"):
+            self.outputNormalizedSetOfTomograms.enableAppend()
+        else:
             outputNormalizedSetOfTomograms = self._createSetOfTomograms(suffix='Normalized')
             outputNormalizedSetOfTomograms.copyInfo(self.inputSetOfTomograms.get())
             if self.binning > 1:
                 samplingRate = self.inputSetOfTomograms.get().getSamplingRate()
                 outputNormalizedSetOfTomograms.setSamplingRate(samplingRate * self.binning.get())
+            outputNormalizedSetOfTomograms.setStreamState(pw.object.Set.STREAM_OPEN)
             self._defineOutputs(outputNormalizedSetOfTomograms=outputNormalizedSetOfTomograms)
             self._defineSourceRelation(self.inputSetOfTomograms, outputNormalizedSetOfTomograms)
         return self.outputNormalizedSetOfTomograms

--- a/imod/protocols/protocol_tomoNormalization.py
+++ b/imod/protocols/protocol_tomoNormalization.py
@@ -25,8 +25,7 @@
 # **************************************************************************
 
 import os
-import numpy as np
-import imod.utils as utils
+import pyworkflow as pw
 import pyworkflow.protocol.params as params
 import pyworkflow.utils.path as path
 from pwem.protocols import EMProtocol

--- a/imod/protocols/protocol_tomoReconstruction.py
+++ b/imod/protocols/protocol_tomoReconstruction.py
@@ -25,15 +25,12 @@
 # **************************************************************************
 
 import os
-import numpy as np
 import pyworkflow as pw
 import pyworkflow.protocol.params as params
 import pyworkflow.utils.path as path
 from pwem.protocols import EMProtocol
-from pwem.emlib.image import ImageHandler
 from tomo.protocols import ProtTomoBase
-from tomo.convert import writeTiStack
-from tomo.objects import Tomogram, TomoAcquisition
+from tomo.objects import Tomogram
 from imod import Plugin
 
 

--- a/imod/protocols/protocol_tomoReconstruction.py
+++ b/imod/protocols/protocol_tomoReconstruction.py
@@ -230,9 +230,12 @@ class ProtImodTomoReconstruction(EMProtocol, ProtTomoBase):
 
     # --------------------------- UTILS functions ----------------------------
     def getOutputSetOfTomograms(self):
-        if not hasattr(self, "outputSetOfTomograms"):
+        if hasattr(self, "outputSetOfTomograms"):
+            self.outputSetOfTomograms.enableAppend()
+        else:
             outputSetOfTomograms = self._createSetOfTomograms()
             outputSetOfTomograms.copyInfo(self.inputSetOfTiltSeries.get())
+            outputSetOfTomograms.setStreamState(pw.object.Set.STREAM_OPEN)
             self._defineOutputs(outputSetOfTomograms=outputSetOfTomograms)
             self._defineSourceRelation(self.inputSetOfTiltSeries, outputSetOfTomograms)
         return self.outputSetOfTomograms

--- a/imod/protocols/protocol_tsNormalization.py
+++ b/imod/protocols/protocol_tsNormalization.py
@@ -25,8 +25,6 @@
 # **************************************************************************
 
 import os
-import numpy as np
-import imod.utils as utils
 import pyworkflow as pw
 import pyworkflow.protocol.params as params
 import pyworkflow.utils.path as path

--- a/imod/protocols/protocol_tsNormalization.py
+++ b/imod/protocols/protocol_tsNormalization.py
@@ -27,6 +27,7 @@
 import os
 import numpy as np
 import imod.utils as utils
+import pyworkflow as pw
 import pyworkflow.protocol.params as params
 import pyworkflow.utils.path as path
 from pwem.protocols import EMProtocol
@@ -244,7 +245,9 @@ class ProtImodTSNormalization(EMProtocol, ProtTomoBase):
 
     # --------------------------- UTILS functions ----------------------------
     def getOutputNormalizedSetOfTiltSeries(self):
-        if not hasattr(self, "outputNormalizedSetOfTiltSeries"):
+        if hasattr(self, "outputNormalizedSetOfTiltSeries"):
+            self.outputNormalizedSetOfTiltSeries.enableAppend()
+        else:
             outputNormalizedSetOfTiltSeries = self._createSetOfTiltSeries(suffix='Normalized')
             outputNormalizedSetOfTiltSeries.copyInfo(self.inputSetOfTiltSeries.get())
             outputNormalizedSetOfTiltSeries.setDim(self.inputSetOfTiltSeries.get().getDim())
@@ -252,6 +255,7 @@ class ProtImodTSNormalization(EMProtocol, ProtTomoBase):
                 samplingRate = self.inputSetOfTiltSeries.get().getSamplingRate()
                 samplingRate *= self.binning.get()
                 outputNormalizedSetOfTiltSeries.setSamplingRate(samplingRate)
+            outputNormalizedSetOfTiltSeries.setStreamState(pw.object.Set.STREAM_OPEN)
             self._defineOutputs(outputNormalizedSetOfTiltSeries=outputNormalizedSetOfTiltSeries)
             self._defineSourceRelation(self.inputSetOfTiltSeries, outputNormalizedSetOfTiltSeries)
         return self.outputNormalizedSetOfTiltSeries

--- a/imod/protocols/protocol_xCorrPrealignment.py
+++ b/imod/protocols/protocol_xCorrPrealignment.py
@@ -27,6 +27,7 @@
 import os
 import imod.utils as utils
 import pwem.objects as data
+import pyworkflow as pw
 import pyworkflow.protocol.params as params
 import pyworkflow.utils.path as path
 from pwem.protocols import EMProtocol
@@ -253,16 +254,21 @@ class ProtImodXcorrPrealignment(EMProtocol, ProtTomoBase):
 
     # --------------------------- UTILS functions ----------------------------
     def getOutputSetOfTiltSeries(self):
-        if not hasattr(self, "outputSetOfTiltSeries"):
+        if hasattr(self, "outputSetOfTiltSeries"):
+            self.outputSetOfTiltSeries.enableAppend()
+        else:
             outputSetOfTiltSeries = self._createSetOfTiltSeries()
             outputSetOfTiltSeries.copyInfo(self.inputSetOfTiltSeries.get())
             outputSetOfTiltSeries.setDim(self.inputSetOfTiltSeries.get().getDim())
+            outputSetOfTiltSeries.setStreamState(pw.object.Set.STREAM_OPEN)
             self._defineOutputs(outputSetOfTiltSeries=outputSetOfTiltSeries)
             self._defineSourceRelation(self.inputSetOfTiltSeries, outputSetOfTiltSeries)
         return self.outputSetOfTiltSeries
 
     def getOutputInterpolatedSetOfTiltSeries(self):
-        if not hasattr(self, "outputInterpolatedSetOfTiltSeries"):
+        if hasattr(self, "outputInterpolatedSetOfTiltSeries"):
+            self.outputInterpolatedSetOfTiltSeries.enableAppend()
+        else:
             outputInterpolatedSetOfTiltSeries = self._createSetOfTiltSeries(suffix='Interpolated')
             outputInterpolatedSetOfTiltSeries.copyInfo(self.inputSetOfTiltSeries.get())
             outputInterpolatedSetOfTiltSeries.setDim(self.inputSetOfTiltSeries.get().getDim())
@@ -270,6 +276,7 @@ class ProtImodXcorrPrealignment(EMProtocol, ProtTomoBase):
                 samplingRate = self.inputSetOfTiltSeries.get().getSamplingRate()
                 samplingRate *= self.binning.get()
                 outputInterpolatedSetOfTiltSeries.setSamplingRate(samplingRate)
+            outputInterpolatedSetOfTiltSeries.setStreamState(pw.object.Set.STREAM_OPEN)
             self._defineOutputs(outputInterpolatedSetOfTiltSeries=outputInterpolatedSetOfTiltSeries)
             self._defineSourceRelation(self.inputSetOfTiltSeries, outputInterpolatedSetOfTiltSeries)
         return self.outputInterpolatedSetOfTiltSeries

--- a/imod/protocols/protocol_xCorrPrealignment.py
+++ b/imod/protocols/protocol_xCorrPrealignment.py
@@ -25,7 +25,6 @@
 # **************************************************************************
 
 import os
-import numpy as np
 import imod.utils as utils
 import pwem.objects as data
 import pyworkflow.protocol.params as params


### PR DESCRIPTION
This PR includes:

- Fixes in output generation in ctfCorrection, ctfEstimation, fidAlignment, tomoNormalization, tomoReconstruction, tsNormalization, xCorrPrealignment protocols.
- Remove deprecated code in ctfEstimation, fidAlignment,  tomoNormalization, tomoReconstruction, tsNormalization, xCorrPrealignment protocols
- Fixes in exclude views in etomo protocol