### PR TITLE
Fi fixes close ouptut sets

### DIFF
--- a/imod/protocols/protocol_ctfCorrecion.py
+++ b/imod/protocols/protocol_ctfCorrecion.py
@@ -90,6 +90,7 @@ class ProtImodCtfCorrection(EMProtocol, ProtTomoBase):
             self._insertFunctionStep('convertInputStep', ts.getObjId())
             self._insertFunctionStep('ctfCorrection', ts.getObjId())
             self._insertFunctionStep('createOutputStep', ts.getObjId())
+        self._insertFunctionStep('closeOutputSetsStep')
 
     # --------------------------- STEPS functions ----------------------------
     def convertInputStep(self, tsObjId):
@@ -172,6 +173,11 @@ class ProtImodCtfCorrection(EMProtocol, ProtTomoBase):
         newTs.write(properties=False)
         outputCtfCorrectedSetOfTiltSeries.update(newTs)
         outputCtfCorrectedSetOfTiltSeries.write()
+        self._store()
+
+    def closeOutputSetsStep(self):
+        self.getOutputCtfCorrectedSetOfTiltSeries().setStreamState(Set.STREAM_CLOSED)
+
         self._store()
 
     # --------------------------- UTILS functions ----------------------------

--- a/imod/protocols/protocol_ctfEstimation.py
+++ b/imod/protocols/protocol_ctfEstimation.py
@@ -263,6 +263,7 @@ class ProtImodCtfEstimation(EMProtocol, ProtTomoBase):
             self._insertFunctionStep('convertInputStep', ts.getObjId())
             self._insertFunctionStep('ctfEstimation', ts.getObjId())
             self._insertFunctionStep('createOutputStep', ts.getObjId())
+        self._insertFunctionStep('closeOutputSetsStep')
 
     # --------------------------- STEPS functions ----------------------------
     def convertInputStep(self, tsObjId):
@@ -394,6 +395,11 @@ class ProtImodCtfEstimation(EMProtocol, ProtTomoBase):
             outputCtfEstimatedSetOfTiltSeries.update(newTs)
             outputCtfEstimatedSetOfTiltSeries.write()
             self._store()
+
+    def closeOutputSetsStep(self):
+        self.getOutputCtfEstimatedSetOfTiltSeries().setStreamState(Set.STREAM_CLOSED)
+
+        self._store()
 
     # --------------------------- UTILS functions ----------------------------
     def getOutputCtfEstimatedSetOfTiltSeries(self):

--- a/imod/protocols/protocol_tomoNormalization.py
+++ b/imod/protocols/protocol_tomoNormalization.py
@@ -158,6 +158,7 @@ class ProtImodTomoNormalization(EMProtocol, ProtTomoBase):
     def _insertAllSteps(self):
         for tomo in self.inputSetOfTomograms.get():
             self._insertFunctionStep('generateOutputStackStep', tomo.getObjId())
+        self._insertFunctionStep('closeOutputSetsStep')
 
     # --------------------------- STEPS functions ----------------------------
     def generateOutputStackStep(self, tsObjId):
@@ -238,6 +239,11 @@ class ProtImodTomoNormalization(EMProtocol, ProtTomoBase):
         outputNormalizedSetOfTomograms.append(newTomogram)
         outputNormalizedSetOfTomograms.update(newTomogram)
         outputNormalizedSetOfTomograms.write()
+        self._store()
+
+    def closeOutputSetsStep(self):
+        self.getOutputNormalizedSetOfTomograms().setStreamState(Set.STREAM_CLOSED)
+
         self._store()
 
     # --------------------------- UTILS functions ----------------------------

--- a/imod/protocols/protocol_tomoProjection.py
+++ b/imod/protocols/protocol_tomoProjection.py
@@ -93,6 +93,7 @@ class ProtImodTomoProjection(EMProtocol, ProtTomoBase):
         for tomo in self.inputSetOfTomograms.get():
             self._insertFunctionStep('projectTomogram', tomo.getObjId())
             self._insertFunctionStep('generateOutputStackStep', tomo.getObjId())
+        self._insertFunctionStep('closeOutputSetsStep')
 
     # --------------------------- STEPS functions ----------------------------
     def projectTomogram(self, tomoObjId):
@@ -152,6 +153,11 @@ class ProtImodTomoProjection(EMProtocol, ProtTomoBase):
         outputProjectedSetOfTiltSeries.update(newTs)
         outputProjectedSetOfTiltSeries.updateDim()
         outputProjectedSetOfTiltSeries.write()
+        self._store()
+
+    def closeOutputSetsStep(self):
+        self.getOutputProjectedSetOfTiltSeries().setStreamState(Set.STREAM_CLOSED)
+
         self._store()
 
     # --------------------------- UTILS functions ----------------------------

--- a/imod/protocols/protocol_tomoReconstruction.py
+++ b/imod/protocols/protocol_tomoReconstruction.py
@@ -152,6 +152,7 @@ class ProtImodTomoReconstruction(EMProtocol, ProtTomoBase):
             self._insertFunctionStep('convertInputStep', ts.getObjId())
             self._insertFunctionStep('computeReconstructionStep', ts.getObjId())
             self._insertFunctionStep('createOutputStep', ts.getObjId())
+        self._insertFunctionStep('closeOutputSetsStep')
 
     # --------------------------- STEPS functions ----------------------------
     def convertInputStep(self, tsObjId):
@@ -248,6 +249,11 @@ class ProtImodTomoReconstruction(EMProtocol, ProtTomoBase):
         outputSetOfTomograms.append(newTomogram)
         outputSetOfTomograms.update(newTomogram)
         outputSetOfTomograms.write()
+        self._store()
+
+    def closeOutputSetsStep(self):
+        self.getOutputSetOfTomograms().setStreamState(Set.STREAM_CLOSED)
+
         self._store()
 
     # --------------------------- UTILS functions ----------------------------

--- a/imod/protocols/protocol_tsNormalization.py
+++ b/imod/protocols/protocol_tsNormalization.py
@@ -160,6 +160,7 @@ class ProtImodTSNormalization(EMProtocol, ProtTomoBase):
         for ts in self.inputSetOfTiltSeries.get():
             self._insertFunctionStep('convertInputStep', ts.getObjId())
             self._insertFunctionStep('generateOutputStackStep', ts.getObjId())
+        self._insertFunctionStep('closeOutputSetsStep')
 
     # --------------------------- STEPS functions ----------------------------
     def convertInputStep(self, tsObjId):
@@ -239,6 +240,11 @@ class ProtImodTSNormalization(EMProtocol, ProtTomoBase):
         outputNormalizedSetOfTiltSeries.update(newTs)
         outputNormalizedSetOfTiltSeries.updateDim()
         outputNormalizedSetOfTiltSeries.write()
+        self._store()
+
+    def closeOutputSetsStep(self):
+        self.getOutputNormalizedSetOfTiltSeries().setStreamState(Set.STREAM_CLOSED)
+
         self._store()
 
     # --------------------------- UTILS functions ----------------------------

--- a/imod/protocols/protocol_xCorrPrealignment.py
+++ b/imod/protocols/protocol_xCorrPrealignment.py
@@ -126,6 +126,7 @@ class ProtImodXcorrPrealignment(EMProtocol, ProtTomoBase):
             self._insertFunctionStep('computeXcorrStep', ts.getObjId())
             if self.computeAlignment.get() == 0:
                 self._insertFunctionStep('computeInterpolatedStackStep', ts.getObjId())
+        self._insertFunctionStep('closeOutputSetsStep')
 
     # --------------------------- STEPS functions ----------------------------
     def convertInputStep(self, tsObjId):
@@ -250,6 +251,12 @@ class ProtImodXcorrPrealignment(EMProtocol, ProtTomoBase):
         outputInterpolatedSetOfTiltSeries.update(newTs)
         outputInterpolatedSetOfTiltSeries.updateDim()
         outputInterpolatedSetOfTiltSeries.write()
+        self._store()
+
+    def closeOutputSetsStep(self):
+        self.getOutputSetOfTiltSeries().setStreamState(Set.STREAM_CLOSED)
+        self.getOutputInterpolatedSetOfTiltSeries().setStreamState(Set.STREAM_CLOSED)
+
         self._store()
 
     # --------------------------- UTILS functions ----------------------------


### PR DESCRIPTION
This PR includes changes to set the stream state to closed in the following protocols:

- Tomo normalization
- Tomo reconstruction
- Tomo projection
- CTF estimation 
- CTF correction
- Tilt-series normalization
- Tilt-series prealignment