### PR TITLE
Fixes in calculate average roation angle

### DIFF
--- a/imod/utils.py
+++ b/imod/utils.py
@@ -859,6 +859,9 @@ def calculateRotationAngleFromTM(ts):
     """ This method calculates que average tilt image rotation angle from its associated transformation matrix."""
     avgRotationAngle = 0
 
+    if not ts.getFirstItem().hasTransform():
+        return avgRotationAngle
+
     for ti in ts:
         tm = ti.getTransform().getMatrix()
         cosRotationAngle = tm[0][0]


### PR DESCRIPTION
This PR includes:
- Fixes in calculate avg rotation angle when ti has no transform: return 0