### PR TITLE
Gs fixes3

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,0 +1,31 @@
+3.1:
+- fix generating ctf output; hide some params from manual ctf protocol; do not run autofit for manual protocol
+- added xform file to ctfphaseflip to rotate astigmatism estimation and adjust for x-shifts for the image center
+- fix excluded views parsing from com files
+- rename "normalization" to "preprocess" protocols
+- handle excluded views properly (closes #137 , closes #147)
+- ctfplotter handles excluded views properly, output ctfs for such views have 0 values
+- fix failed ts generation in fid.alignment protocol
+- pep8 fixes, add pip-related files
+- mtffilter was missing pixelsize param, causing wrong filter being applied (always with 1A/px)
+- add antialias param to ts norm protocol
+- fix wrong default naming style for etomo
+- enable robust fitting for beadtracker
+- remove redundant updateDim calls
+- get acquisition from ts when creating a tomo
+- fix pixsize and dims for etomo outputs (closes #139)
+- fix beadtrack args to match copytomocoms script
+- always use antialias when binning a stack
+- two surfaces search is off in both protocols for consistency
+- bead radius default is 18px (good range for bin 4 and 10nm beads)
+- use sobel filter for bead centering for most cryo data
+- use lowpass for bead tracking
+- use adjustbeadsizes
+- trimvol -yz replaced by -rx, the first one flips the hand
+- add expandcircles to eraser
+- replace wrong dose file format for mtffilter
+- set output 3D coord size based on bead diameter
+- fix betterradius param in gold eraser tab of the fid alignment
+- add missing pix size in fid align
+- fix minpacing in gold picker
+- add missing taper arg for newstack

--- a/imod/__init__.py
+++ b/imod/__init__.py
@@ -36,7 +36,7 @@ import pwem
 from .constants import IMOD_HOME, ETOMO_CMD, DEFAULT_VERSION, VERSIONS
 
 
-__version__ = '3.0.11'
+__version__ = '3.1'
 _logo = ""
 _references = ['Kremer1996', 'Mastronarde2017']
 

--- a/imod/__init__.py
+++ b/imod/__init__.py
@@ -152,14 +152,17 @@ class Plugin(pwem.Plugin):
     def runImod(cls, protocol, program, args, cwd=None):
         """ Run IMOD command from a given protocol. """
 
+        ncpus = protocol.numberOfThreads.get()
+
         # Get the command
-        cmd = cls.getImodCmd(program)
+        cmd = cls.getImodCmd(program, ncpus)
 
         # Run the protocol with that command
-        protocol.runJob(cmd, args, env=cls.getEnviron(), cwd=cwd)
+        protocol.runJob(cmd, args, env=cls.getEnviron(), cwd=cwd,
+                        numberOfMpi=1, numberOfThreads=1)
 
     @classmethod
-    def getImodCmd(cls, program):
+    def getImodCmd(cls, program, ncpus=1):
         """ Composes an IMOD command for a given program. """
 
         # Program to run
@@ -167,6 +170,9 @@ class Plugin(pwem.Plugin):
 
         # Command to run
         cmd = ""
+
+        if ncpus > 1:
+            cmd += f"export IMOD_PROCESSORS={ncpus} && "
 
         # If absolute ... (then it is based on the config)
         if os.path.isabs(program):

--- a/imod/protocols/protocol_base.py
+++ b/imod/protocols/protocol_base.py
@@ -431,12 +431,12 @@ class ProtImodBase(ProtTomoImportFiles, EMProtocol, ProtTomoBase):
 
             " Plain estimation (any defocus flag)"
             newCTFTomo._defocusUList = CsvList(pType=float)
-            newCTFTomo.setDefocusUList(defocusUDict.get(index + 1, [-999.]))
+            newCTFTomo.setDefocusUList(defocusUDict.get(index + 1, [0.]))
 
             if defocusFileFlag == 1:
                 " Astigmatism estimation "
                 newCTFTomo._defocusVList = CsvList(pType=float)
-                newCTFTomo.setDefocusVList(defocusVDict.get(index + 1, [-999.]))
+                newCTFTomo.setDefocusVList(defocusVDict.get(index + 1, [0.]))
 
                 newCTFTomo._defocusAngleList = CsvList(pType=float)
                 newCTFTomo.setDefocusAngleList(defocusAngleDict.get(index + 1, [0.]))
@@ -449,7 +449,7 @@ class ProtImodBase(ProtTomoImportFiles, EMProtocol, ProtTomoBase):
             elif defocusFileFlag == 5:
                 " Astigmatism and phase shift estimation "
                 newCTFTomo._defocusVList = CsvList(pType=float)
-                newCTFTomo.setDefocusVList(defocusVDict.get(index + 1, [-999.]))
+                newCTFTomo.setDefocusVList(defocusVDict.get(index + 1, [0.]))
 
                 newCTFTomo._defocusAngleList = CsvList(pType=float)
                 newCTFTomo.setDefocusAngleList(defocusAngleDict.get(index + 1, [0.]))
@@ -460,7 +460,7 @@ class ProtImodBase(ProtTomoImportFiles, EMProtocol, ProtTomoBase):
             elif defocusFileFlag == 37:
                 " Astigmatism, phase shift and cut-on frequency estimation "
                 newCTFTomo._defocusVList = CsvList(pType=float)
-                newCTFTomo.setDefocusVList(defocusVDict.get(index + 1, [-999.]))
+                newCTFTomo.setDefocusVList(defocusVDict.get(index + 1, [0.]))
 
                 newCTFTomo._defocusAngleList = CsvList(pType=float)
                 newCTFTomo.setDefocusAngleList(defocusAngleDict.get(index + 1, [0.]))

--- a/imod/protocols/protocol_base.py
+++ b/imod/protocols/protocol_base.py
@@ -344,7 +344,7 @@ class ProtImodBase(ProtTomoImportFiles, EMProtocol, ProtTomoBase):
 
     def getOutputSetOfCTFTomoSeries(self, outputSetName):
 
-        outputSetOfCTFTomoSeries = getattr(self, outputSetName)
+        outputSetOfCTFTomoSeries = getattr(self, outputSetName, None)
 
         if outputSetOfCTFTomoSeries:
             outputSetOfCTFTomoSeries.enableAppend()

--- a/imod/protocols/protocol_base.py
+++ b/imod/protocols/protocol_base.py
@@ -382,7 +382,7 @@ class ProtImodBase(ProtTomoImportFiles, EMProtocol, ProtTomoBase):
 
         # We need to create now all the attributes of this object
         # in order to append it to the set and be
-        # able to update it posteriorly.
+        # able to update it later.
 
         newCTFTomoSeries.setNumberOfEstimationsInRange(None)
 
@@ -417,75 +417,59 @@ class ProtImodBase(ProtTomoImportFiles, EMProtocol, ProtTomoBase):
 
         else:
             raise Exception(
-                "Defocus file flag do not supported. Only supported formats "
-                "corresponding to flags 0, 1, 4, 5, and 37.")
+                f"Defocus file flag {defocusFileFlag} is not supported. Only supported formats "
+                "correspond to flags 0, 1, 4, 5, and 37.")
 
+        excludedViews = inputTs.getExcludedViewsIndex()
         for index, _ in enumerate(inputTs):
             newCTFTomo = CTFTomo()
             newCTFTomo.setIndex(Integer(index + 1))
 
-            if (index + 1) not in defocusUDict.keys():
+            if (index + 1) not in defocusUDict.keys() and (index + 1) not in excludedViews:
                 raise Exception("ERROR IN TILT-SERIES %s: NO CTF ESTIMATED FOR VIEW %d, TILT ANGLE %f" % (
                     tsId, (index + 1), inputTs[index + 1].getTiltAngle()))
 
-            if defocusFileFlag == 0:
-                " Plain estimation "
-                newCTFTomo._defocusUList = CsvList(pType=float)
-                newCTFTomo.setDefocusUList(defocusUDict[index + 1])
+            " Plain estimation (any defocus flag)"
+            newCTFTomo._defocusUList = CsvList(pType=float)
+            newCTFTomo.setDefocusUList(defocusUDict.get(index + 1, [-999.]))
 
-            elif defocusFileFlag == 1:
+            if defocusFileFlag == 1:
                 " Astigmatism estimation "
-                newCTFTomo._defocusUList = CsvList(pType=float)
-                newCTFTomo.setDefocusUList(defocusUDict[index + 1])
-
                 newCTFTomo._defocusVList = CsvList(pType=float)
-                newCTFTomo.setDefocusVList(defocusVDict[index + 1])
+                newCTFTomo.setDefocusVList(defocusVDict.get(index + 1, [-999.]))
 
                 newCTFTomo._defocusAngleList = CsvList(pType=float)
-                newCTFTomo.setDefocusAngleList(defocusAngleDict[index + 1])
+                newCTFTomo.setDefocusAngleList(defocusAngleDict.get(index + 1, [0.]))
 
             elif defocusFileFlag == 4:
                 " Phase-shift information "
-                newCTFTomo._defocusUList = CsvList(pType=float)
-                newCTFTomo.setDefocusUList(defocusUDict[index + 1])
-
                 newCTFTomo._phaseShiftList = CsvList(pType=float)
-                newCTFTomo.setPhaseShiftList(phaseShiftDict[index + 1])
+                newCTFTomo.setPhaseShiftList(phaseShiftDict.get(index + 1, [0.]))
 
             elif defocusFileFlag == 5:
                 " Astigmatism and phase shift estimation "
-                newCTFTomo._defocusUList = CsvList(pType=float)
-                newCTFTomo.setDefocusUList(defocusUDict[index + 1])
-
                 newCTFTomo._defocusVList = CsvList(pType=float)
-                newCTFTomo.setDefocusVList(defocusVDict[index + 1])
+                newCTFTomo.setDefocusVList(defocusVDict.get(index + 1, [-999.]))
 
                 newCTFTomo._defocusAngleList = CsvList(pType=float)
-                newCTFTomo.setDefocusAngleList(defocusAngleDict[index + 1])
+                newCTFTomo.setDefocusAngleList(defocusAngleDict.get(index + 1, [0.]))
 
                 newCTFTomo._phaseShiftList = CsvList(pType=float)
-                newCTFTomo.setPhaseShiftList(phaseShiftDict[index + 1])
+                newCTFTomo.setPhaseShiftList(phaseShiftDict.get(index + 1, [0.]))
 
             elif defocusFileFlag == 37:
                 " Astigmatism, phase shift and cut-on frequency estimation "
-                newCTFTomo._defocusUList = CsvList(pType=float)
-                newCTFTomo.setDefocusUList(defocusUDict[index + 1])
-
                 newCTFTomo._defocusVList = CsvList(pType=float)
-                newCTFTomo.setDefocusVList(defocusVDict[index + 1])
+                newCTFTomo.setDefocusVList(defocusVDict.get(index + 1, [-999.]))
 
                 newCTFTomo._defocusAngleList = CsvList(pType=float)
-                newCTFTomo.setDefocusAngleList(defocusAngleDict[index + 1])
+                newCTFTomo.setDefocusAngleList(defocusAngleDict.get(index + 1, [0.]))
 
                 newCTFTomo._phaseShiftList = CsvList(pType=float)
-                newCTFTomo.setPhaseShiftList(phaseShiftDict[index + 1])
+                newCTFTomo.setPhaseShiftList(phaseShiftDict.get(index + 1, [0.]))
 
                 newCTFTomo._cutOnFreqList = CsvList(pType=float)
-                newCTFTomo.setCutOnFreqList(cutOnFreqDict[index + 1])
-
-                defocusUDict, defocusVDict, defocusAngleDict, phaseShiftDict, cutOnFreqDict = \
-                    utils.readCTFEstimationInfoFile(defocusFilePath,
-                                                    flag=defocusFileFlag)
+                newCTFTomo.setCutOnFreqList(cutOnFreqDict.get(index + 1, [0.]))
 
             newCTFTomo.completeInfoFromList()
 

--- a/imod/protocols/protocol_base.py
+++ b/imod/protocols/protocol_base.py
@@ -26,7 +26,7 @@
 
 import os
 
-from pyworkflow.object import Set, CsvList, Integer, Pointer
+from pyworkflow.object import Set, CsvList, Pointer
 from pyworkflow.protocol import STEPS_PARALLEL
 from pyworkflow.utils import path
 from pwem.protocols import EMProtocol
@@ -421,55 +421,56 @@ class ProtImodBase(ProtTomoImportFiles, EMProtocol, ProtTomoBase):
                 "correspond to flags 0, 1, 4, 5, and 37.")
 
         excludedViews = inputTs.getExcludedViewsIndex()
-        for index, _ in enumerate(inputTs):
+        ids = inputTs.getIdSet()
+        for index in ids:
             newCTFTomo = CTFTomo()
-            newCTFTomo.setIndex(Integer(index + 1))
+            newCTFTomo.setIndex(index)
 
-            if (index + 1) not in defocusUDict.keys() and (index + 1) not in excludedViews:
+            if index not in defocusUDict.keys() and index not in excludedViews:
                 raise Exception("ERROR IN TILT-SERIES %s: NO CTF ESTIMATED FOR VIEW %d, TILT ANGLE %f" % (
-                    tsId, (index + 1), inputTs[index + 1].getTiltAngle()))
+                    tsId, index, inputTs[index].getTiltAngle()))
 
             " Plain estimation (any defocus flag)"
             newCTFTomo._defocusUList = CsvList(pType=float)
-            newCTFTomo.setDefocusUList(defocusUDict.get(index + 1, [0.]))
+            newCTFTomo.setDefocusUList(defocusUDict.get(index, [0.]))
 
             if defocusFileFlag == 1:
                 " Astigmatism estimation "
                 newCTFTomo._defocusVList = CsvList(pType=float)
-                newCTFTomo.setDefocusVList(defocusVDict.get(index + 1, [0.]))
+                newCTFTomo.setDefocusVList(defocusVDict.get(index, [0.]))
 
                 newCTFTomo._defocusAngleList = CsvList(pType=float)
-                newCTFTomo.setDefocusAngleList(defocusAngleDict.get(index + 1, [0.]))
+                newCTFTomo.setDefocusAngleList(defocusAngleDict.get(index, [0.]))
 
             elif defocusFileFlag == 4:
                 " Phase-shift information "
                 newCTFTomo._phaseShiftList = CsvList(pType=float)
-                newCTFTomo.setPhaseShiftList(phaseShiftDict.get(index + 1, [0.]))
+                newCTFTomo.setPhaseShiftList(phaseShiftDict.get(index, [0.]))
 
             elif defocusFileFlag == 5:
                 " Astigmatism and phase shift estimation "
                 newCTFTomo._defocusVList = CsvList(pType=float)
-                newCTFTomo.setDefocusVList(defocusVDict.get(index + 1, [0.]))
+                newCTFTomo.setDefocusVList(defocusVDict.get(index, [0.]))
 
                 newCTFTomo._defocusAngleList = CsvList(pType=float)
-                newCTFTomo.setDefocusAngleList(defocusAngleDict.get(index + 1, [0.]))
+                newCTFTomo.setDefocusAngleList(defocusAngleDict.get(index, [0.]))
 
                 newCTFTomo._phaseShiftList = CsvList(pType=float)
-                newCTFTomo.setPhaseShiftList(phaseShiftDict.get(index + 1, [0.]))
+                newCTFTomo.setPhaseShiftList(phaseShiftDict.get(index, [0.]))
 
             elif defocusFileFlag == 37:
                 " Astigmatism, phase shift and cut-on frequency estimation "
                 newCTFTomo._defocusVList = CsvList(pType=float)
-                newCTFTomo.setDefocusVList(defocusVDict.get(index + 1, [0.]))
+                newCTFTomo.setDefocusVList(defocusVDict.get(index, [0.]))
 
                 newCTFTomo._defocusAngleList = CsvList(pType=float)
-                newCTFTomo.setDefocusAngleList(defocusAngleDict.get(index + 1, [0.]))
+                newCTFTomo.setDefocusAngleList(defocusAngleDict.get(index, [0.]))
 
                 newCTFTomo._phaseShiftList = CsvList(pType=float)
-                newCTFTomo.setPhaseShiftList(phaseShiftDict.get(index + 1, [0.]))
+                newCTFTomo.setPhaseShiftList(phaseShiftDict.get(index, [0.]))
 
                 newCTFTomo._cutOnFreqList = CsvList(pType=float)
-                newCTFTomo.setCutOnFreqList(cutOnFreqDict.get(index + 1, [0.]))
+                newCTFTomo.setCutOnFreqList(cutOnFreqDict.get(index, [0.]))
 
             newCTFTomo.completeInfoFromList()
 

--- a/imod/protocols/protocol_ctfCorrection.py
+++ b/imod/protocols/protocol_ctfCorrection.py
@@ -169,7 +169,6 @@ class ProtImodCtfCorrection(ProtImodBase):
             'angleFile': os.path.join(tmpPrefix, ts.getFirstItem().parseFileName(extension=".tlt")),
             'outputFileName': os.path.join(extraPrefix, ts.getFirstItem().parseFileName()),
             'defocusFile': self.getDefocusFileName(ts),
-            'xformFile': os.path.join(tmpPrefix, ts.getFirstItem().parseFileName(extension=".xf")),
             'voltage': self.inputSetOfTiltSeries.get().getAcquisition().getVoltage(),
             'sphericalAberration': self.inputSetOfTiltSeries.get().getAcquisition().getSphericalAberration(),
             'defocusTol': self.defocusTol.get(),
@@ -182,7 +181,6 @@ class ProtImodCtfCorrection(ProtImodBase):
                            "-AngleFile %(angleFile)s " \
                            "-OutputFileName %(outputFileName)s " \
                            "-DefocusFile %(defocusFile)s " \
-                           "-TransformFile %(xformFile)s " \
                            "-Voltage %(voltage)d " \
                            "-SphericalAberration %(sphericalAberration)f " \
                            "-DefocusTol %(defocusTol)d " \
@@ -196,6 +194,10 @@ class ProtImodCtfCorrection(ProtImodBase):
             })
 
             argsCtfPhaseFlip += "-UseGPU %(useGPU)d "
+
+        if ts.firstItem.hasTransform():
+            paramsCtfPhaseFlip['xformFile'] = os.path.join(tmpPrefix, ts.getFirstItem().parseFileName(extension=".xf"))
+            argsCtfPhaseFlip += "-TransformFile %(xformFile)s "
 
         Plugin.runImod(self, 'ctfphaseflip', argsCtfPhaseFlip % paramsCtfPhaseFlip)
 

--- a/imod/protocols/protocol_ctfCorrection.py
+++ b/imod/protocols/protocol_ctfCorrection.py
@@ -55,7 +55,8 @@ class ProtImodCtfCorrection(ProtImodBase):
                       label="Input tilt-series",
                       pointerClass='SetOfTiltSeries',
                       help='Select the set of tilt-series to be '
-                           'CTF corrected.')
+                           'CTF corrected. Usually this will be the '
+                           'tilt-series with alignment information.')
 
         form.addParam('inputSetOfCtfTomoSeries',
                       params.PointerParam,
@@ -118,7 +119,6 @@ class ProtImodCtfCorrection(ProtImodBase):
         form.addHidden(params.GPU_LIST,
                        params.StringParam,
                        default='0',
-                       expertLevel=params.LEVEL_ADVANCED,
                        label="Choose GPU IDs",
                        help="GPU ID. To pick the best available one set 0. "
                             "For a specific GPU set its number ID "
@@ -169,18 +169,20 @@ class ProtImodCtfCorrection(ProtImodBase):
             'angleFile': os.path.join(tmpPrefix, ts.getFirstItem().parseFileName(extension=".tlt")),
             'outputFileName': os.path.join(extraPrefix, ts.getFirstItem().parseFileName()),
             'defocusFile': self.getDefocusFileName(ts),
+            'xformFile': os.path.join(tmpPrefix, ts.getFirstItem().parseFileName(extension=".xf")),
             'voltage': self.inputSetOfTiltSeries.get().getAcquisition().getVoltage(),
             'sphericalAberration': self.inputSetOfTiltSeries.get().getAcquisition().getSphericalAberration(),
             'defocusTol': self.defocusTol.get(),
             'pixelSize': self.inputSetOfTiltSeries.get().getSamplingRate() / 10,
             'amplitudeContrast': self.inputSetOfTiltSeries.get().getAcquisition().getAmplitudeContrast(),
-            'interpolationWidth': self.interpolationWidth.get(),
+            'interpolationWidth': self.interpolationWidth.get()
         }
 
         argsCtfPhaseFlip = "-InputStack %(inputStack)s " \
                            "-AngleFile %(angleFile)s " \
                            "-OutputFileName %(outputFileName)s " \
                            "-DefocusFile %(defocusFile)s " \
+                           "-TransformFile %(xformFile)s " \
                            "-Voltage %(voltage)d " \
                            "-SphericalAberration %(sphericalAberration)f " \
                            "-DefocusTol %(defocusTol)d " \

--- a/imod/protocols/protocol_ctfCorrection.py
+++ b/imod/protocols/protocol_ctfCorrection.py
@@ -195,7 +195,7 @@ class ProtImodCtfCorrection(ProtImodBase):
 
             argsCtfPhaseFlip += "-UseGPU %(useGPU)d "
 
-        if ts.firstItem.hasTransform():
+        if ts.getFirstItem().hasTransform():
             paramsCtfPhaseFlip['xformFile'] = os.path.join(tmpPrefix, ts.getFirstItem().parseFileName(extension=".xf"))
             argsCtfPhaseFlip += "-TransformFile %(xformFile)s "
 

--- a/imod/protocols/protocol_ctfCorrection.py
+++ b/imod/protocols/protocol_ctfCorrection.py
@@ -189,11 +189,8 @@ class ProtImodCtfCorrection(ProtImodBase):
                            "-InterpolationWidth %(interpolationWidth)d "
 
         if self.usesGpu():
-            paramsCtfPhaseFlip.update({
-                "useGPU": self.getGpuList()[0]
-            })
-
-            argsCtfPhaseFlip += "-UseGPU %(useGPU)d "
+            argsCtfPhaseFlip += f"-UseGPU {self.getGpuList()[0]} " \
+                                "-ActionIfGPUFails 2,2 "
 
         if ts.getFirstItem().hasTransform():
             paramsCtfPhaseFlip['xformFile'] = os.path.join(tmpPrefix, ts.getFirstItem().parseFileName(extension=".xf"))

--- a/imod/protocols/protocol_ctfEstimation_automatic.py
+++ b/imod/protocols/protocol_ctfEstimation_automatic.py
@@ -366,6 +366,11 @@ class ProtImodAutomaticCtfEstimation(ProtImodBase):
                          "-RightDefTol %(rightDefTol)f " \
                          "-tileSize %(tileSize)d "
 
+        # Excluded views
+        excludedViews = ts.getExcludedViewsIndex(caster=str)
+        if len(excludedViews):
+            argsCtfPlotter += f"-ViewsToSkip {','.join(excludedViews)} "
+
         if self._interactiveMode:
             argsCtfPlotter += "-AngleRange -20.0,20.0 "
         else:

--- a/imod/protocols/protocol_ctfEstimation_automatic.py
+++ b/imod/protocols/protocol_ctfEstimation_automatic.py
@@ -42,7 +42,7 @@ class ProtImodAutomaticCtfEstimation(ProtImodBase):
         https://bio3d.colorado.edu/imod/doc/man/ctfplotter.html
     """
 
-    _label = 'Automatic CTF estimation (step 1)'
+    _label = 'Automatic CTF estimation'
     _devStatus = BETA
 
     defocusUTolerance = 20
@@ -137,160 +137,161 @@ class ProtImodAutomaticCtfEstimation(ProtImodBase):
                            "square. Each view is first divided into strips "
                            "that are considered to have constant defocus.")
 
-        groupAngleRange = form.addGroup('Autorefinement angle settings',
-                                        help='This entry sets the range of '
-                                             'angles for each fit and the step '
-                                             'size between angles for the '
-                                             'initial autofitting of the whole '
-                                             'tilt-series.')
+        if not self._interactiveMode:
+            groupAngleRange = form.addGroup('Autorefinement angle settings',
+                                            help='This entry sets the range of '
+                                                 'angles for each fit and the step '
+                                                 'size between angles for the '
+                                                 'initial autofitting of the whole '
+                                                 'tilt-series.')
 
-        groupAngleRange.addParam('angleStep',
-                                 params.FloatParam,
-                                 default=2,
-                                 label='Angle step',
-                                 help='Step size between ranges. A value of '
-                                      'zero for the step will make it fit to '
-                                      'each single image separately, '
-                                      'regardless of the value for the range.')
-
-        groupAngleRange.addParam('angleRange',
-                                 params.FloatParam,
-                                 condition="angleStep != 0",
-                                 default=16,
-                                 label='Angle range',
-                                 help='Size of the angle range for which the '
-                                      'CTF is estimated.')
-
-        groupFrequencyRange = form.addGroup('Autorefinement frequency range',
-                                            expertLevel=params.LEVEL_ADVANCED,
-                                            help='Starting and ending frequencies '
-                                                 'of range to fit in power spectrum. '
-                                                 'The two values will be used to '
-                                                 'set the "X1 starts" and "X2 ends" '
-                                                 'fields in the fitting dialog.')
-
-        groupFrequencyRange.addParam('startFreq',
+            groupAngleRange.addParam('angleStep',
                                      params.FloatParam,
-                                     default=0.0,
-                                     label='Start',
-                                     help='Starting frequency (X1 starts)')
+                                     default=2,
+                                     label='Angle step',
+                                     help='Step size between ranges. A value of '
+                                          'zero for the step will make it fit to '
+                                          'each single image separately, '
+                                          'regardless of the value for the range.')
 
-        groupFrequencyRange.addParam('endFreq',
+            groupAngleRange.addParam('angleRange',
                                      params.FloatParam,
-                                     default=0.0,
-                                     label='End',
-                                     help='Ending frequency (X2 ends)')
+                                     condition="angleStep != 0",
+                                     default=16,
+                                     label='Angle range',
+                                     help='Size of the angle range for which the '
+                                          'CTF is estimated.')
 
-        form.addParam('extraZerosToFit',
-                      params.FloatParam,
-                      label='Extra zeros to fit',
-                      default=0.0,
-                      expertLevel=params.LEVEL_ADVANCED,
-                      help="By default, the ending frequency of the fitting "
-                           "range is set to the expected location of "
-                           "the second zero. With this entry, the range will "
-                           "be extended by the given multiple of the interval "
-                           "between first and seconds zeros. For example, "
-                           "entries of 1 and 2 will fit approximately to the "
-                           "third and fourth zeros, respectively. An entry of "
-                           "more than 0.5 will trigger fitting to two "
-                           "exponentials, which is important for fitting "
-                           "multiple peaks between zeros.")
+            groupFrequencyRange = form.addGroup('Autorefinement frequency range',
+                                                expertLevel=params.LEVEL_ADVANCED,
+                                                help='Starting and ending frequencies '
+                                                     'of range to fit in power spectrum. '
+                                                     'The two values will be used to '
+                                                     'set the "X1 starts" and "X2 ends" '
+                                                     'fields in the fitting dialog.')
 
-        form.addParam('skipAstigmaticViews',
-                      params.EnumParam,
-                      choices=['Yes', 'No'],
-                      default=1,
-                      label='Skip astigmatic phase views?',
-                      expertLevel=params.LEVEL_ADVANCED,
-                      display=params.EnumParam.DISPLAY_HLIST,
-                      help='Skip or break views only when finding astigmatism '
-                           'or phase shift')
+            groupFrequencyRange.addParam('startFreq',
+                                         params.FloatParam,
+                                         default=0.0,
+                                         label='Start',
+                                         help='Starting frequency (X1 starts)')
 
-        groupAstigmatism = form.addGroup('Astigmatism settings',
-                                         help='Parameters for astigmatism analysis')
+            groupFrequencyRange.addParam('endFreq',
+                                         params.FloatParam,
+                                         default=0.0,
+                                         label='End',
+                                         help='Ending frequency (X2 ends)')
 
-        groupAstigmatism.addParam('searchAstigmatism',
-                                  params.EnumParam,
-                                  choices=['Yes', 'No'],
-                                  default=1,
-                                  label='Search astigmatism?',
-                                  display=params.EnumParam.DISPLAY_HLIST,
-                                  help='Search for astigmatism when fitting.')
+            form.addParam('extraZerosToFit',
+                          params.FloatParam,
+                          label='Extra zeros to fit',
+                          default=0.0,
+                          expertLevel=params.LEVEL_ADVANCED,
+                          help="By default, the ending frequency of the fitting "
+                               "range is set to the expected location of "
+                               "the second zero. With this entry, the range will "
+                               "be extended by the given multiple of the interval "
+                               "between first and seconds zeros. For example, "
+                               "entries of 1 and 2 will fit approximately to the "
+                               "third and fourth zeros, respectively. An entry of "
+                               "more than 0.5 will trigger fitting to two "
+                               "exponentials, which is important for fitting "
+                               "multiple peaks between zeros.")
 
-        groupAstigmatism.addParam('maximumAstigmatism',
-                                  params.FloatParam,
-                                  default=1.2,
-                                  label='Maximum astigmatism (um)',
-                                  condition='searchAstigmatism==0',
-                                  help='Maximum astigmatism, in microns. '
-                                       'During the fitting to wedge spectra, '
-                                       'the defocus is allowed to vary from '
-                                       'the global value by more than half '
-                                       'of this amount.')
+            form.addParam('skipAstigmaticViews',
+                          params.EnumParam,
+                          choices=['Yes', 'No'],
+                          default=1,
+                          label='Skip astigmatic phase views?',
+                          expertLevel=params.LEVEL_ADVANCED,
+                          display=params.EnumParam.DISPLAY_HLIST,
+                          help='Skip or break views only when finding astigmatism '
+                               'or phase shift')
 
-        groupAstigmatism.addParam('numberSectorsAstigmatism',
-                                  params.IntParam,
-                                  default=36,
-                                  label='Number of sectors',
-                                  condition='searchAstigmatism==0',
-                                  help='Number of sectors for astigmatism '
-                                       'analysis.  A power spectrum is stored '
-                                       'separately for each sector; spectra '
-                                       'can then be computed fairly quickly '
-                                       'for wedges of any size that is a '
-                                       'multiple of the sector size. The '
-                                       'default is 36, giving 5 degree sectors.')
+            groupAstigmatism = form.addGroup('Astigmatism settings',
+                                             help='Parameters for astigmatism analysis')
 
-        groupAstigmatism.addParam('minimumViewsAstigmatism',
-                                  params.IntParam,
-                                  default=3,
-                                  label='Minimum views astigmatism',
-                                  condition='searchAstigmatism==0',
-                                  help='Minimum number of views for '
-                                       'finding astigmatism.')
+            groupAstigmatism.addParam('searchAstigmatism',
+                                      params.EnumParam,
+                                      choices=['Yes', 'No'],
+                                      default=1,
+                                      label='Search astigmatism?',
+                                      display=params.EnumParam.DISPLAY_HLIST,
+                                      help='Search for astigmatism when fitting.')
 
-        groupPhaseShift = form.addGroup('Phase shift settings',
-                                        help='Parameters for phase shift analysis')
+            groupAstigmatism.addParam('maximumAstigmatism',
+                                      params.FloatParam,
+                                      default=1.2,
+                                      label='Maximum astigmatism (um)',
+                                      condition='searchAstigmatism==0',
+                                      help='Maximum astigmatism, in microns. '
+                                           'During the fitting to wedge spectra, '
+                                           'the defocus is allowed to vary from '
+                                           'the global value by more than half '
+                                           'of this amount.')
 
-        groupPhaseShift.addParam('searchPhaseShift',
-                                 params.EnumParam,
-                                 choices=['Yes', 'No'],
-                                 default=1,
-                                 label='Search phase shift?',
-                                 display=params.EnumParam.DISPLAY_HLIST,
-                                 help='Search for phase shift when fitting.')
+            groupAstigmatism.addParam('numberSectorsAstigmatism',
+                                      params.IntParam,
+                                      default=36,
+                                      label='Number of sectors',
+                                      condition='searchAstigmatism==0',
+                                      help='Number of sectors for astigmatism '
+                                           'analysis.  A power spectrum is stored '
+                                           'separately for each sector; spectra '
+                                           'can then be computed fairly quickly '
+                                           'for wedges of any size that is a '
+                                           'multiple of the sector size. The '
+                                           'default is 36, giving 5 degree sectors.')
 
-        groupPhaseShift.addParam('minimumViewsPhaseShift',
-                                 params.IntParam,
-                                 default=1,
-                                 label='Minimum views phase shift',
-                                 condition='searchPhaseShift==0',
-                                 help='Minimum number of views for '
-                                      'finding phase shift.')
+            groupAstigmatism.addParam('minimumViewsAstigmatism',
+                                      params.IntParam,
+                                      default=3,
+                                      label='Minimum views astigmatism',
+                                      condition='searchAstigmatism==0',
+                                      help='Minimum number of views for '
+                                           'finding astigmatism.')
 
-        groupCutOnFreq = form.addGroup('Cut-on frequency settings')
+            groupPhaseShift = form.addGroup('Phase shift settings',
+                                            help='Parameters for phase shift analysis')
 
-        groupCutOnFreq.addParam('searchCutOnFreq',
-                                params.EnumParam,
-                                choices=['Yes', 'No'],
-                                default=1,
-                                label='Search cut-on frequency?',
-                                display=params.EnumParam.DISPLAY_HLIST,
-                                help='Search for cut-on frequency when '
-                                     'finding phase shift.')
+            groupPhaseShift.addParam('searchPhaseShift',
+                                     params.EnumParam,
+                                     choices=['Yes', 'No'],
+                                     default=1,
+                                     label='Search phase shift?',
+                                     display=params.EnumParam.DISPLAY_HLIST,
+                                     help='Search for phase shift when fitting.')
 
-        groupCutOnFreq.addParam('maximumCutOnFreq',
-                                params.FloatParam,
-                                default=-1,
-                                label='Maximum astigmatism (um)',
-                                condition='searchCutOnFreq==0',
-                                help='Maximum frequency to test when searching '
-                                     'for cut-on frequency, in reciprocal '
-                                     'nanometers.  The default is the '
-                                     'frequency of the first zero at the '
-                                     'expected defocus and phase shift. '
-                                     'To use the default value set box to -1.')
+            groupPhaseShift.addParam('minimumViewsPhaseShift',
+                                     params.IntParam,
+                                     default=1,
+                                     label='Minimum views phase shift',
+                                     condition='searchPhaseShift==0',
+                                     help='Minimum number of views for '
+                                          'finding phase shift.')
+
+            groupCutOnFreq = form.addGroup('Cut-on frequency settings')
+
+            groupCutOnFreq.addParam('searchCutOnFreq',
+                                    params.EnumParam,
+                                    choices=['Yes', 'No'],
+                                    default=1,
+                                    label='Search cut-on frequency?',
+                                    display=params.EnumParam.DISPLAY_HLIST,
+                                    help='Search for cut-on frequency when '
+                                         'finding phase shift.')
+
+            groupCutOnFreq.addParam('maximumCutOnFreq',
+                                    params.FloatParam,
+                                    default=-1,
+                                    label='Maximum astigmatism (1/nm)',
+                                    condition='searchCutOnFreq==0',
+                                    help='Maximum frequency to test when searching '
+                                         'for cut-on frequency, in reciprocal '
+                                         'nanometers.  The default is the '
+                                         'frequency of the first zero at the '
+                                         'expected defocus and phase shift. '
+                                         'To use the default value set box to -1.')
 
     # -------------------------- INSERT steps functions -----------------------
     def _getSetOfTiltSeries(self, pointer=False):
@@ -340,7 +341,6 @@ class ProtImodAutomaticCtfEstimation(ProtImodBase):
             'axisAngle': ts.getAcquisition().getTiltAxisAngle(),
             'pixelSize': tsSet.getSamplingRate() / 10,
             'expectedDefocus': self.getExpectedDefocus(tsId),
-            'autoFitRangeAndStep': str(self.angleRange.get()) + "," + str(self.angleStep.get()),
             'voltage': tsSet.getAcquisition().getVoltage(),
             'sphericalAberration': tsSet.getAcquisition().getSphericalAberration(),
             'amplitudeContrast': tsSet.getAcquisition().getAmplitudeContrast(),
@@ -357,7 +357,6 @@ class ProtImodAutomaticCtfEstimation(ProtImodBase):
                          "-AxisAngle %(axisAngle)f " \
                          "-PixelSize %(pixelSize)f " \
                          "-ExpectedDefocus %(expectedDefocus)f " \
-                         "-AutoFitRangeAndStep %(autoFitRangeAndStep)s " \
                          "-Voltage %(voltage)d " \
                          "-SphericalAberration %(sphericalAberration)f " \
                          "-AmplitudeContrast %(amplitudeContrast)f " \
@@ -367,68 +366,73 @@ class ProtImodAutomaticCtfEstimation(ProtImodBase):
                          "-RightDefTol %(rightDefTol)f " \
                          "-tileSize %(tileSize)d "
 
-        if self.startFreq.get() != 0 or self.endFreq.get() != 0:
-            paramsCtfPlotter.update({
-                'startFreq': self.startFreq.get(),
-                'endFreq': self.endFreq.get(),
-            })
+        if self._interactiveMode:
+            argsCtfPlotter += "-AngleRange -20.0,20.0 "
+        else:
 
-            argsCtfPlotter += "-FrequencyRangeToFit %(startFreq)f,%(endFreq)f "
-
-        if self.extraZerosToFit.get() != 0:
-            paramsCtfPlotter.update({
-                'extraZerosToFit': self.extraZerosToFit.get(),
-            })
-
-            argsCtfPlotter += "-ExtraZerosToFit %(extraZerosToFit)f "
-
-        if self.skipAstigmaticViews.get() == 0:
-            argsCtfPlotter += "-SkipOnlyForAstigPhase "
-
-        if self.searchAstigmatism.get() == 0:
-            paramsCtfPlotter.update({
-                'maximumAstigmatism': self.maximumAstigmatism.get(),
-                'numberOfSectors': self.numberSectorsAstigmatism.get(),
-                'minimumViewsAstigmatism': self.minimumViewsAstigmatism.get()
-            })
-
-            argsCtfPlotter += "-SearchAstigmatism " \
-                              "-MaximumAstigmatism %(maximumAstigmatism)f " \
-                              "-NumberOfSectors %(numberOfSectors)d "
-
-        if self.searchPhaseShift.get() == 0:
-            paramsCtfPlotter.update({
-                'minimumViewsPhaseShift': self.minimumViewsPhaseShift.get()
-            })
-
-            argsCtfPlotter += "-SearchPhaseShift "
-
-        if self.searchAstigmatism.get() == 0 and self.searchPhaseShift.get() == 0:
-            argsCtfPlotter += "-MinViewsAstigAndPhase %(minimumViewsAstigmatism)d,%(minimumViewsPhaseShift)d "
-        elif self.searchAstigmatism.get() == 0:
-            argsCtfPlotter += "-MinViewsAstigAndPhase %(minimumViewsAstigmatism)d,0 "
-        elif self.searchPhaseShift.get() == 0:
-            argsCtfPlotter += "-MinViewsAstigAndPhase 0,%(minimumViewsPhaseShift)d "
-
-        if self.searchCutOnFreq.get() == 0:
-
-            if self.maximumCutOnFreq.get() == -1:
-                argsCtfPlotter += "-SearchCutonFrequency "
-
-            else:
+            if self.extraZerosToFit.get() != 0:
                 paramsCtfPlotter.update({
-                    'maximumCutOnFreq': self.maximumCutOnFreq.get(),
+                    'extraZerosToFit': self.extraZerosToFit.get(),
                 })
 
-                argsCtfPlotter += "-SearchCutonFrequency " \
-                                  "-MaxCutOnToSearch %(maximumCutOnFreq)f "
+                argsCtfPlotter += "-ExtraZerosToFit %(extraZerosToFit)f "
 
-        if not self._interactiveMode:
-            argsCtfPlotter += "-SaveAndExit "
+            if self.skipAstigmaticViews.get() == 0:
+                argsCtfPlotter += "-SkipOnlyForAstigPhase "
+
+            if self.searchAstigmatism.get() == 0:
+                paramsCtfPlotter.update({
+                    'maximumAstigmatism': self.maximumAstigmatism.get(),
+                    'numberOfSectors': self.numberSectorsAstigmatism.get(),
+                    'minimumViewsAstigmatism': self.minimumViewsAstigmatism.get()
+                })
+
+                argsCtfPlotter += "-SearchAstigmatism " \
+                                  "-MaximumAstigmatism %(maximumAstigmatism)f " \
+                                  "-NumberOfSectors %(numberOfSectors)d "
+
+            if self.searchPhaseShift.get() == 0:
+                paramsCtfPlotter.update({
+                    'minimumViewsPhaseShift': self.minimumViewsPhaseShift.get()
+                })
+
+                argsCtfPlotter += "-SearchPhaseShift "
+
+            if self.searchAstigmatism.get() == 0 and self.searchPhaseShift.get() == 0:
+                argsCtfPlotter += "-MinViewsAstigAndPhase %(minimumViewsAstigmatism)d,%(minimumViewsPhaseShift)d "
+            elif self.searchAstigmatism.get() == 0:
+                argsCtfPlotter += "-MinViewsAstigAndPhase %(minimumViewsAstigmatism)d,0 "
+            elif self.searchPhaseShift.get() == 0:
+                argsCtfPlotter += "-MinViewsAstigAndPhase 0,%(minimumViewsPhaseShift)d "
+
+            if self.searchCutOnFreq.get() == 0:
+
+                if self.maximumCutOnFreq.get() == -1:
+                    argsCtfPlotter += "-SearchCutonFrequency "
+
+                else:
+                    paramsCtfPlotter.update({
+                        'maximumCutOnFreq': self.maximumCutOnFreq.get(),
+                    })
+
+                    argsCtfPlotter += "-SearchCutonFrequency " \
+                                      "-MaxCutOnToSearch %(maximumCutOnFreq)f "
+
+            paramsCtfPlotter['autoFitRangeAndStep'] = str(self.angleRange.get()) + "," + str(self.angleStep.get())
+            argsCtfPlotter += "-SaveAndExit " \
+                              "-AutoFitRangeAndStep %(autoFitRangeAndStep)s "
+
+            if self.startFreq.get() != 0 or self.endFreq.get() != 0:
+                paramsCtfPlotter.update({
+                    'startFreq': self.startFreq.get(),
+                    'endFreq': self.endFreq.get(),
+                })
+
+                argsCtfPlotter += "-FrequencyRangeToFit %(startFreq)f,%(endFreq)f "
 
         Plugin.runImod(self, 'ctfplotter', argsCtfPlotter % paramsCtfPlotter)
 
-    def createOutputStep(self, tsObjId):
+    def createOutputStep(self, tsObjId, outputSetName=OUTPUT_CTF_SERIE):
         ts = self._getTiltSeries(tsObjId)
         tsId = ts.getTsId()
 
@@ -438,14 +442,14 @@ class ProtImodAutomaticCtfEstimation(ProtImodBase):
                                        ts.getFirstItem().parseFileName(extension=".defocus"))
 
         if os.path.exists(defocusFilePath):
-            output = self.getOutputSetOfCTFTomoSeries(OUTPUT_CTF_SERIE)
+            output = self.getOutputSetOfCTFTomoSeries(outputSetName)
 
             self.addCTFTomoSeriesToSetFromDefocusFile(ts, defocusFilePath, output)
 
     def closeOutputSetsStep(self):
-
-        self.CTFTomoSeries.setStreamState(Set.STREAM_CLOSED)
-        self.CTFTomoSeries.write()
+        for _, output in self.iterOutputAttributes():
+            output.setStreamState(Set.STREAM_CLOSED)
+            output.write()
         self._store()
 
     # --------------------------- UTILS functions -----------------------------

--- a/imod/protocols/protocol_ctfEstimation_manual.py
+++ b/imod/protocols/protocol_ctfEstimation_manual.py
@@ -25,32 +25,30 @@
 # *
 # **************************************************************************
 
-import os
-
 from pyworkflow import BETA
 from tomo.objects import SetOfCTFTomoSeries
 
 from .protocol_ctfEstimation_automatic import ProtImodAutomaticCtfEstimation
+from .protocol_base import OUTPUT_CTF_SERIE
 
 
 class ProtImodManualCtfEstimation(ProtImodAutomaticCtfEstimation):
     """
     CTF estimation of a set of input tilt-series using the IMOD procedure.
-    Run the protocol through the interactive GUI. Defocus values are saved
-    to file and exit after autofitting. The program will not ask for confirmation before
-    removing existing entries in the defocus table. If run in interactive mode defocus values
+    Runs the protocol through the interactive GUI. The resulting defocus values
     MUST BE SAVED manually by the user.
     More info:
         https://bio3d.colorado.edu/imod/doc/man/ctfplotter.html
 
     """
 
-    _label = 'Manual CTF estimation (step 2)'
+    _label = 'Manual CTF estimation'
     _devStatus = BETA
     _interactiveMode = True
 
     def __init__(self, **args):
         ProtImodAutomaticCtfEstimation.__init__(self, **args)
+        self.OUTPUT_PREFIX = OUTPUT_CTF_SERIE
 
     def _insertAllSteps(self):
         self.inputTiltSeries = None
@@ -66,6 +64,7 @@ class ProtImodManualCtfEstimation(ProtImodAutomaticCtfEstimation):
                                  isInteractive=True,
                                  itemDoubleClick=True)
         view.show()
+        self.createOutput()
 
     def runAllSteps(self, obj):
         objId = obj.getObjId()
@@ -83,12 +82,3 @@ class ProtImodManualCtfEstimation(ProtImodAutomaticCtfEstimation):
     def _summary(self):
         summary = []
         return summary
-
-    # ------------------ UTILS METHODS ------------------------------------
-
-    def getFilePath(self, ts, suffix="", extension=""):
-        tsId = ts.getTsId()
-        extraPrefix = self._getExtraPath(tsId)
-        return os.path.join(extraPrefix,
-                            ts.getFirstItem().parseFileName(suffix=suffix,
-                                                            extension=extension))

--- a/imod/protocols/protocol_etomo.py
+++ b/imod/protocols/protocol_etomo.py
@@ -75,6 +75,8 @@ class ProtImodEtomo(ProtImodBase):
                       label='Fiducial markers diameter (nm)',
                       help='Diameter of gold beads in nanometers.')
 
+        form.addParallelSection(threads=1, mpi=0)
+
     # -------------------------- INSERT steps functions -----------------------
     # Overwrite the following function to prevent streaming from base class
     def _stepsCheck(self):
@@ -161,7 +163,8 @@ class ProtImodEtomo(ProtImodBase):
                                 'minTilt': minTilt,
                                 'markerDiameter': self.markersDiameter,
                                 'rotationAngle': ts.getAcquisition().getTiltAxisAngle(),
-                                'imodDir': Plugin.getHome()
+                                'imodDir': Plugin.getHome(),
+                                'useCpu': self.numberOfThreads > 1
                             })
 
     def runEtomo(self, ts):
@@ -532,6 +535,7 @@ Setup.Stack.A.Is.Twodir=false
 Setup.Pos.B.NewDialog=true
 ProcessTrack.TomogramPositioning-B=Not started
 Setup.Combine.PatchBoundaryZMax=0
+Setup.DefaultParallel=%(useCpu)s
 Setup.DefaultGpuProcessing=false
 Setup.Track.A.SeedModel.Auto=true
 Setup.Combine.PatchSize=M
@@ -539,7 +543,6 @@ Setup.AxisB.TiltAngle.Type=Extract
 Setup.Combine.PatchBoundaryZMin=0
 Setup.ProjectLog.FrameLocation.Y=55
 Setup.ProjectLog.FrameLocation.X=95
-Setup.DefaultParallel=false
 Setup.ProjectLog.Visible=true
 Setup.tiltalign.NumberOfLocalPatchesXandY=5,5
 Setup.Combine.PatchRegionModel=

--- a/imod/protocols/protocol_etomo.py
+++ b/imod/protocols/protocol_etomo.py
@@ -30,7 +30,6 @@ import os
 
 import pyworkflow as pw
 from pyworkflow import BETA
-from pyworkflow.object import Set
 import pyworkflow.protocol.params as params
 import pyworkflow.utils.path as path
 from pwem.emlib.image import ImageHandler

--- a/imod/protocols/protocol_etomo.py
+++ b/imod/protocols/protocol_etomo.py
@@ -30,6 +30,7 @@ import os
 
 import pyworkflow as pw
 from pyworkflow import BETA
+from pyworkflow.object import Set
 import pyworkflow.protocol.params as params
 import pyworkflow.utils.path as path
 from pwem.emlib.image import ImageHandler

--- a/imod/protocols/protocol_etomo.py
+++ b/imod/protocols/protocol_etomo.py
@@ -342,9 +342,10 @@ class ProtImodEtomo(ProtImodBase):
 
                 landmarkModelNoGapsFilePath = self.getFilePath(ts, suffix="_nogaps", extension=".sfid")
                 fiducialNoGapsResidList = utils.formatFiducialResidList(residFilePath)
-                landmarkModelNoGaps = tomoObj.LandmarkModel(tsId,
-                                                            landmarkModelNoGapsFilePath,
-                                                            modelFilePath)
+                landmarkModelNoGaps = tomoObj.LandmarkModel(tsId=tsId,
+                                                            fileName=landmarkModelNoGapsFilePath,
+                                                            modelName=modelFilePath,
+                                                            size=self.markersDiameter.get() * 10 / ts.getSamplingRate())
 
                 prevTiltIm = 0
                 chainId = 0

--- a/imod/protocols/protocol_fiducialAlignment.py
+++ b/imod/protocols/protocol_fiducialAlignment.py
@@ -265,7 +265,7 @@ class ProtImodFiducialAlignment(ProtImodBase):
 
             if self.computeAlignment.get() == 0 or self.eraseGoldBeads.get() == 0:
                 self._insertFunctionStep(self.computeOutputInterpolatedStackStep,
-                                         tsObjId, tsIdsDict)
+                                         tsObjId)
 
             if self.eraseGoldBeads.get() == 0:
                 self._insertFunctionStep(self.eraseGoldBeadsStep, tsObjId)
@@ -285,6 +285,7 @@ class ProtImodFiducialAlignment(ProtImodBase):
             try:
                 func(self, tsId)
             except:
+                self.error(f"{func.__name__} has failed for tilt-series objId#{tsId}")
                 self._failedTs.append(tsId)
 
         return wrapper
@@ -442,6 +443,7 @@ class ProtImodFiducialAlignment(ProtImodBase):
                                     ts.getSize(),
                                     ts.getSamplingRate())
 
+    @tryExceptDecorator
     def translateFiducialPointModelStep(self, tsObjId):
         ts = self.inputSetOfTiltSeries.get()[tsObjId]
         tsId = ts.getTsId()
@@ -467,6 +469,7 @@ class ProtImodFiducialAlignment(ProtImodBase):
 
             Plugin.runImod(self, 'model2point', argsNoGapModel2Point % paramsNoGapModel2Point)
 
+    @tryExceptDecorator
     def computeOutputStackStep(self, tsObjId):
         ts = self.inputSetOfTiltSeries.get()[tsObjId]
         tsId = ts.getTsId()
@@ -533,7 +536,8 @@ class ProtImodFiducialAlignment(ProtImodBase):
                 "Error (computeOutputStackStep): \n Imod output file "
                 "%s does not exist or it is empty" % tmpFileName)
 
-    def computeOutputInterpolatedStackStep(self, tsObjId, tsIdsDict):
+    @tryExceptDecorator
+    def computeOutputInterpolatedStackStep(self, tsObjId):
         tsIn = self.inputSetOfTiltSeries.get()[tsObjId]
         tsId = tsIn.getTsId()
 
@@ -676,6 +680,7 @@ class ProtImodFiducialAlignment(ProtImodBase):
 
         Plugin.runImod(self, 'ccderaser', argsCcderaser % paramsCcderaser)
 
+    @tryExceptDecorator
     def computeOutputModelsStep(self, tsObjId):
         ts = self.inputSetOfTiltSeries.get()[tsObjId]
         tsId = ts.getTsId()

--- a/imod/protocols/protocol_fiducialAlignment.py
+++ b/imod/protocols/protocol_fiducialAlignment.py
@@ -676,7 +676,6 @@ class ProtImodFiducialAlignment(ProtImodBase):
         extraPrefix = self._getExtraPath(tsId)
 
         firstItem = ts.getFirstItem()
-        XDim, YDim, ZDim = firstItem.getDimensions()
 
         # Create the output set of landmark models with no gaps
         if os.path.exists(

--- a/imod/protocols/protocol_fiducialAlignment.py
+++ b/imod/protocols/protocol_fiducialAlignment.py
@@ -426,8 +426,14 @@ class ProtImodFiducialAlignment(ProtImodBase):
                         "-LocalXStretchDefaultGrouping %(localXStretchDefaultGrouping)s " \
                         "-LocalSkewOption %(localSkewOption)d " \
                         "-LocalSkewDefaultGrouping %(localSkewDefaultGrouping)d " \
-                        "-RobustFitting " \
-                        "2>&1 | tee %(outputTiltAlignFileText)s "
+                        "-RobustFitting "
+
+        # Excluded views
+        excludedViews = ts.getExcludedViewsIndex(caster=str)
+        if len(excludedViews):
+            argsTiltAlign += f"-ExcludeList {','.join(excludedViews)} "
+
+        argsTiltAlign += "2>&1 | tee %(outputTiltAlignFileText)s "
 
         Plugin.runImod(self, 'tiltalign', argsTiltAlign % paramsTiltAlign)
 

--- a/imod/protocols/protocol_fiducialModel.py
+++ b/imod/protocols/protocol_fiducialModel.py
@@ -316,6 +316,11 @@ class ProtImodFiducialModel(ProtImodBase):
                         "-DeletionCriterionMinAndSD %(deletionCriterionMinAndSD)s " \
                         "-MinDiamForParamScaling %(minDiamForParamScaling).1f "
 
+        # Excluded views
+        excludedViews = ts.getExcludedViewsIndex(caster=str)
+        if len(excludedViews):
+            argsBeadtrack += f"-SkipViews {','.join(excludedViews)} "
+
         Plugin.runImod(self, 'beadtrack', argsBeadtrack % paramsBeadtrack)
 
     def translateFiducialPointModelStep(self, tsObjId):
@@ -523,6 +528,11 @@ MinDiamForParamScaling %(minDiamForParamScaling).1f
             template += """SobelFilterCentering
 ScalableSigmaForSobel   %(scalableSigmaForSobelFilter)f
 """
+        # Excluded views
+        excludedViews = ts.getExcludedViewsIndex(caster=str)
+        if len(excludedViews):
+            template += f"SkipViews {','.join(excludedViews)}"
+
         with open(trackFilePath, 'w') as f:
             f.write(template % paramsDict)
 

--- a/imod/protocols/protocol_goldBeadPicker3d.py
+++ b/imod/protocols/protocol_goldBeadPicker3d.py
@@ -103,8 +103,6 @@ class ProtImodGoldBeadPicker3d(ProtImodBase):
                            'The default is 0.9. A value less than 1 is '
                            'helpful for picking both beads in a pair.')
 
-        form.addParallelSection(threads=4, mpi=1)
-
     # -------------------------- INSERT steps functions -----------------------
     def _insertAllSteps(self):
         self.defineExecutionPararell()

--- a/imod/protocols/protocol_goldBeadPicker3d.py
+++ b/imod/protocols/protocol_goldBeadPicker3d.py
@@ -56,7 +56,9 @@ class ProtImodGoldBeadPicker3d(ProtImodBase):
                       important=True,
                       label='Input set of tomograms',
                       help='Input set of tomograms from which gold beads '
-                           'will be picked.')
+                           'will be picked. A tomogram needs to be thicker '
+                           'than normal because the program cannot find '
+                           'beads too close to the surfaces of a tomogram.')
 
         form.addParam('beadDiameter',
                       params.FloatParam,
@@ -150,6 +152,7 @@ class ProtImodGoldBeadPicker3d(ProtImodBase):
                           "-OutputFile %(outputFile)s " \
                           "-BeadSize %(beadSize)d " \
                           "-MinRelativeStrength %(minRelativeStrength)f " \
+                          "-StorageThreshold 0.0 " \
                           "-MinSpacing %(minSpacing)f "
 
         if self.beadsColor.get() == 1:

--- a/imod/protocols/protocol_importSetOfTM.py
+++ b/imod/protocols/protocol_importSetOfTM.py
@@ -127,7 +127,7 @@ class ProtImodImportTransformationMatrix(ProtImodBase):
 
                     ids = ts.getIdSet()
                     for index in ids:
-                        inputTransformMatrix = inputTransformMatrixList[:, :, index]
+                        inputTransformMatrix = inputTransformMatrixList[:, :, index-1]
 
                         outputTransformMatrix = inputTransformMatrix
                         outputTransformMatrix[0][0] = inputTransformMatrix[0][0]

--- a/imod/protocols/protocol_importSetOfTM.py
+++ b/imod/protocols/protocol_importSetOfTM.py
@@ -118,14 +118,15 @@ class ProtImodImportTransformationMatrix(ProtImodBase):
                     extraPrefix = self._getExtraPath(tsId)
                     path.makePath(extraPrefix)
 
-                    # Update shits from the transformation matrix considering
-                    # the matching bining between the input tilt
+                    # Update shifts from the transformation matrix considering
+                    # the matching binning between the input tilt
                     # series and the transformation matrix. We create an empty
                     # tilt-series containing only tilt-images
                     # with transform information.
                     transformMatrixList = []
 
-                    for index, ti in enumerate(ts):
+                    ids = ts.getIdSet()
+                    for index in ids:
                         inputTransformMatrix = inputTransformMatrixList[:, :, index]
 
                         outputTransformMatrix = inputTransformMatrix

--- a/imod/protocols/protocol_tomoNormalization.py
+++ b/imod/protocols/protocol_tomoNormalization.py
@@ -44,7 +44,7 @@ class ProtImodTomoNormalization(ProtImodBase):
         https://bio3D.colorado.edu/imod/doc/binvol.html
     """
 
-    _label = 'Tomo normalization'
+    _label = 'Tomo preprocess'
     _devStatus = BETA
 
     # -------------------------- DEFINE param functions -----------------------

--- a/imod/protocols/protocol_tomoReconstruction.py
+++ b/imod/protocols/protocol_tomoReconstruction.py
@@ -214,13 +214,8 @@ class ProtImodTomoReconstruction(ProtImodBase):
             argsTilt += f"-EXCLUDELIST2 {','.join(excludedViews)} "
 
         if self.usesGpu():
-            paramsTilt.update({
-                "useGPU": self.getGpuList()[0],
-                "actionIfGPUFails": "2,2",
-            })
-
-            argsTilt += "-UseGPU %(useGPU)d " \
-                        "-ActionIfGPUFails %(actionIfGPUFails)s "
+            argsTilt += f"-UseGPU {self.getGpuList()[0]} " \
+                        "-ActionIfGPUFails 2,2 "
 
         Plugin.runImod(self, 'tilt', argsTilt % paramsTilt)
 

--- a/imod/protocols/protocol_tomoReconstruction.py
+++ b/imod/protocols/protocol_tomoReconstruction.py
@@ -208,11 +208,10 @@ class ProtImodTomoReconstruction(ProtImodBase):
             })
             argsTilt += "-FakeSIRTiterations %(FakeSIRTInteractions)d "
 
-        # Excluded views:
-        exclusedViews = ts.getExcludedViewsIndex(caster=str)
-        if len(exclusedViews):
-            paramsTilt.update({'exc': ",".join(exclusedViews)})
-            argsTilt += "-EXCLUDELIST2 %(exc)s "
+        # Excluded views
+        excludedViews = ts.getExcludedViewsIndex(caster=str)
+        if len(excludedViews):
+            argsTilt += f"-EXCLUDELIST2 {','.join(excludedViews)} "
 
         if self.usesGpu():
             paramsTilt.update({

--- a/imod/protocols/protocol_tsNormalization.py
+++ b/imod/protocols/protocol_tsNormalization.py
@@ -42,7 +42,7 @@ class ProtImodTSNormalization(ProtImodBase):
         https://bio3d.colorado.edu/imod/doc/man/newstack.html
     """
 
-    _label = 'Tilt-series normalization'
+    _label = 'Tilt-series preprocess'
     _devStatus = BETA
 
     # -------------------------- DEFINE param functions -----------------------

--- a/imod/protocols/protocol_tsNormalization.py
+++ b/imod/protocols/protocol_tsNormalization.py
@@ -285,8 +285,8 @@ class ProtImodTSNormalization(ProtImodBase):
         transform = newTi.getTransform()
         matrix = transform.getMatrix()
 
-        matrix[0][2] = matrix[0][2] / self.binning.get()
-        matrix[1][2] = matrix[1][2] / self.binning.get()
+        matrix[0][2] /= self.binning.get()
+        matrix[1][2] /= self.binning.get()
 
         transform.setMatrix(matrix)
         newTi.setTransform(transform)

--- a/imod/protocols/protocol_xCorrPrealignment.py
+++ b/imod/protocols/protocol_xCorrPrealignment.py
@@ -183,6 +183,11 @@ class ProtImodXcorrPrealignment(ProtImodBase):
         if self.cumulativeCorr == 0:
             argsXcorr += "-CumulativeCorrelation "
 
+        # Excluded views
+        excludedViews = ts.getExcludedViewsIndex(caster=str)
+        if len(excludedViews):
+            argsXcorr += f"-SkipViews {','.join(excludedViews)} "
+
         Plugin.runImod(self, 'tiltxcorr', argsXcorr % paramsXcorr)
 
         paramsXftoxg = {

--- a/imod/protocols/protocol_xRaysEraser.py
+++ b/imod/protocols/protocol_xRaysEraser.py
@@ -80,7 +80,7 @@ class ProtImodXraysEraser(ProtImodBase):
         form.addParam('maximumRadius',
                       params.FloatParam,
                       default=4.2,
-                      label='Maximum radius (pixels)',
+                      label='Maximum radius (px)',
                       expertLevel=params.LEVEL_ADVANCED,
                       help='Maximum radius of peak area to erase (the '
                            'default is 4.2 pixels).')

--- a/imod/viewers/viewers.py
+++ b/imod/viewers/viewers.py
@@ -36,7 +36,6 @@ import tomo.objects
 
 import imod.protocols
 from ..protocols.protocol_base import (OUTPUT_TILTSERIES_NAME,
-                                       OUTPUT_COORDINATES_3D_NAME,
                                        OUTPUT_FIDUCIAL_NO_GAPS_NAME)
 from .views_tkinter_tree import (ImodGenericViewer, ImodSetView,
                                  ImodSetOfLandmarkModelsView, ImodSetOfTomogramsView)
@@ -78,7 +77,7 @@ class ImodViewer(pwviewer.Viewer):
 class ImodObjectView(pwviewer.CommandView):
     """ Wrapper to visualize different type of objects with the 3dmod """
 
-    def __init__(self, obj, protocol=None,**kwargs):
+    def __init__(self, obj, protocol=None, **kwargs):
         """
 
         :param obj: Object to deal with usually a single item in a set
@@ -91,12 +90,12 @@ class ImodObjectView(pwviewer.CommandView):
 
         elif isinstance(obj, tomo.objects.LandmarkModel):
 
-            if obj.getTiltSeries().hasAlignment() and obj.applyTSTransformation() :
+            if obj.getTiltSeries().hasAlignment() and obj.applyTSTransformation():
                 # Input and output extensions must match if we want to apply the transform with Xmipp
                 _, extension = os.path.splitext(obj.getTiltSeries().getFirstItem().getFileName())
 
                 outputTSPath = os.path.join(tempfile.gettempdir(),
-                                "ts_interpolated_%s_%s_%s%s" % (
+                                            "ts_interpolated_%s_%s_%s%s" % (
                                                 protocol.getProject().getShortName(),
                                                 protocol.getObjId(),
                                                 obj.getObjId(),
@@ -106,7 +105,6 @@ class ImodObjectView(pwviewer.CommandView):
                     obj.getTiltSeries().applyTransform(outputTSPath)
 
             else:
-
                 outputTSPath = obj.getTiltSeries().getFirstItem().getFileName()
 
             fidFileName = obj.getModelName()
@@ -140,7 +138,7 @@ class ImodEtomoViewer(pwviewer.ProtocolViewer):
         group.addParam('saved3DCoord', params.LabelParam,
                        label="3D Coordinates")
         group.addParam('savedFiducials', params.LabelParam,
-                       label="Landmark models no gaps")
+                       label="Landmark models with no gaps")
 
         group = form.addGroup('Tomogram')
         group.addParam('savedReconsTomo', params.LabelParam,

--- a/imod/viewers/views_tkinter_tree.py
+++ b/imod/viewers/views_tkinter_tree.py
@@ -26,10 +26,6 @@
 
 import tempfile
 import threading
-import tkinter
-from tkinter import *
-from matplotlib.figure import Figure
-from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
 
 from pyworkflow.gui import *
 from pyworkflow.gui.tree import TreeProvider
@@ -401,7 +397,7 @@ class ImodSetOfLandmarkModelsView(pwviewer.CommandView):
 
             else:
                 self._cmd += Plugin.getImodCmd('3dmod') + " -m " + itemComplete.getTiltSeries().getFirstItem().getFileName() + \
-                      " " + itemComplete.getModelName() + " ; "
+                             " " + itemComplete.getModelName() + " ; "
 
         super().show()
 


### PR DESCRIPTION
To be merged after #148 
- fix generating ctf output; hide some params from manual ctf protocol; do not run autofit for manual protocol
- added xform file to ctfphaseflip to rotate astigmatism estimation and adjust for x-shifts for the image center
- fix excluded views parsing from com files
- rename "normalization" to "preprocess" protocols
- handle excluded views properly (closes #137 , closes #147)
- ctfplotter handles excluded views properly, output ctfs for such views have 0 values
- fix failed ts generation in fid.alignment protocol
- add number of threads to etomo protocol, so that ctfphaseflip and tilt can be run in parallel
