### PR TITLE
more fixes

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 3.1:
+- remove transformation step from imod ctf estimation (ctf is estimated on raw ts stack)
 - fix rotation angle range for swapping x/y for newstack
 - do not copy objId for apply TM protocol when excluding views
 - fix output size in apply TM protocol

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,7 @@
 3.1:
+- fix rotation angle range for swapping x/y for newstack
+- do not copy objId for apply TM protocol when excluding views
+- fix output size in apply TM protocol
 - fix wrong output file index numbers in the exclude views protocol
 - fix gold erasing option in the fid. alignment protocol
 - fix generating ctf output; hide some params from manual ctf protocol; do not run autofit for manual protocol

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 3.1:
+- fix gold erasing option in the fid. alignment protocol
 - fix generating ctf output; hide some params from manual ctf protocol; do not run autofit for manual protocol
 - added xform file to ctfphaseflip to rotate astigmatism estimation and adjust for x-shifts for the image center
 - fix excluded views parsing from com files

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 3.1:
+- fix wrong output file index numbers in the exclude views protocol
 - fix gold erasing option in the fid. alignment protocol
 - fix generating ctf output; hide some params from manual ctf protocol; do not run autofit for manual protocol
 - added xform file to ctfphaseflip to rotate astigmatism estimation and adjust for x-shifts for the image center

--- a/README.rst
+++ b/README.rst
@@ -61,7 +61,24 @@ Supported versions
 Protocols
 ---------
 
-tbd
+* apply transformation
+* automatic CTF estimation
+* CTF correction
+* coarse prealignment
+* dose filter
+* etomo interactive
+* exclude views
+* fiducial alignment
+* generate fiducial model
+* gold bead picker 3D
+* import tomo CTFs
+* import transformation matrix
+* manual CTF estimation
+* tilt-series preprocess
+* tomo preprocess
+* tomo projection
+* tomo reconstruction
+* X-rays eraser
 
 References
 ----------

--- a/imod/protocols/protocol_applyTransformationMatrix.py
+++ b/imod/protocols/protocol_applyTransformationMatrix.py
@@ -110,9 +110,10 @@ class ProtImodApplyTransformationMatrix(ProtImodBase):
         # Check if rotation angle is greater than 45º. If so,
         # swap x and y dimensions to adapt output image sizes to
         # the final sample disposition.
-        if rotationAngleAvg > 45 or rotationAngleAvg < -45:
+        if 45 < abs(rotationAngleAvg) < 135:
             paramsAlignment.update({
-                'size': "%d,%d" % (firstItem.getYDim(), firstItem.getXDim())
+                'size': "%d,%d" % (firstItem.getYDim() // self.binning.get(),
+                                   firstItem.getXDim() // self.binning.get())
             })
 
             argsAlignment += "-size %(size)s "
@@ -142,7 +143,7 @@ class ProtImodApplyTransformationMatrix(ProtImodBase):
         for tiltImage in ts:
             if tiltImage.isEnabled():
                 newTi = TiltImage()
-                newTi.copyInfo(tiltImage, copyId=True, copyTM=False)
+                newTi.copyInfo(tiltImage, copyId=False, copyTM=False)
                 newTi.setAcquisition(tiltImage.getAcquisition())
                 newTi.setLocation(index, (os.path.join(extraPrefix, tiltImage.parseFileName())))
                 index += 1
@@ -153,8 +154,8 @@ class ProtImodApplyTransformationMatrix(ProtImodBase):
         ih = ImageHandler()
         x, y, z, _ = ih.getDimensions(newTs.getFirstItem().getFileName())
         newTs.setDim((x, y, z))
-        newTs.write(properties=False)
 
+        newTs.write(properties=False)
         output.update(newTs)
         output.write()
         self._store()

--- a/imod/protocols/protocol_applyTransformationMatrix.py
+++ b/imod/protocols/protocol_applyTransformationMatrix.py
@@ -80,7 +80,7 @@ class ProtImodApplyTransformationMatrix(ProtImodBase):
         path.makePath(extraPrefix)
         utils.formatTransformFile(ts,
                                   os.path.join(extraPrefix,
-                                               ts.getFirstItem().parseFileName(extension="_fid.xf")))
+                                               ts.getFirstItem().parseFileName(extension=".xf")))
 
     def computeAlignmentStep(self, tsObjId):
         ts = self.inputSetOfTiltSeries.get()[tsObjId]
@@ -93,7 +93,7 @@ class ProtImodApplyTransformationMatrix(ProtImodBase):
         paramsAlignment = {
             'input': firstItem.getFileName(),
             'output': os.path.join(extraPrefix, firstItem.parseFileName()),
-            'xform': os.path.join(extraPrefix, firstItem.parseFileName(extension="_fid.xf")),
+            'xform': os.path.join(extraPrefix, firstItem.parseFileName(extension=".xf")),
             'bin': int(self.binning.get()),
             'imagebinned': 1.0
         }

--- a/imod/protocols/protocol_base.py
+++ b/imod/protocols/protocol_base.py
@@ -122,7 +122,7 @@ class ProtImodBase(ProtTomoImportFiles, EMProtocol, ProtTomoBase):
                 # Check if rotation angle is greater than 45º. If so,
                 # swap x and y dimensions to adapt output image sizes to
                 # the final sample disposition.
-                if rotationAngleAvg > 45 or rotationAngleAvg < -45:
+                if 45 < abs(rotationAngleAvg) < 135:
                     paramsAlignment.update({
                         'size': "%d,%d" % (firstItem.getYDim(), firstItem.getXDim())
                     })

--- a/imod/protocols/protocol_ctfCorrection.py
+++ b/imod/protocols/protocol_ctfCorrection.py
@@ -235,6 +235,18 @@ class ProtImodCtfCorrection(ProtImodBase):
                 return ctfTomoSeries
 
     # --------------------------- INFO functions ------------------------------
+    def _warnings(self):
+        warnings = []
+        ts = self.inputSetOfTiltSeries.get()
+        if not ts.getFirstItem().getFirstItem().hasTransform():
+            warnings.append("Input tilt-series do not have alignment "
+                            "information! The recommended workflow is to "
+                            "estimate CTF on raw tilt-series and then here "
+                            "provide tilt-series with alignment "
+                            "(non-interpolated).")
+
+        return warnings
+
     def _validate(self):
         validateMsgs = []
 

--- a/imod/protocols/protocol_ctfEstimation_manual.py
+++ b/imod/protocols/protocol_ctfEstimation_manual.py
@@ -69,7 +69,8 @@ class ProtImodManualCtfEstimation(ProtImodAutomaticCtfEstimation):
     def runAllSteps(self, obj):
         objId = obj.getObjId()
         self.convertInputStep(objId)
-        self.ctfEstimation(objId)
+        expDefoci = self.getExpectedDefocus()
+        self.ctfEstimation(objId, expDefoci)
 
     def createOutput(self):
         suffix = self._getOutputSuffix(SetOfCTFTomoSeries)

--- a/imod/protocols/protocol_excludeViews.py
+++ b/imod/protocols/protocol_excludeViews.py
@@ -74,8 +74,8 @@ class ProtImodExcludeViews(ProtImodBase):
                            'separated list of ranges with no spaces between '
                            'them (e.g., 1,4-5,60-70). \n\n'
                            'An example of this file comes as follows:\n'
-                           'stack1 1,4-6,8,44-47\n'
-                           'stack2 3,10-12,24\n'
+                           'TS_01 1,4-6,8,44-47\n'
+                           'TS_02 3,10-12,24\n'
                            '...')
 
     # -------------------------- INSERT steps functions -----------------------
@@ -161,7 +161,7 @@ class ProtImodExcludeViews(ProtImodBase):
         for index, tiltImage in enumerate(ts):
             if (index + 1) not in excludedViews:
                 newTi = tomoObj.TiltImage()
-                newTi.copyInfo(tiltImage, copyId=True, copyTM=True)
+                newTi.copyInfo(tiltImage, copyId=False, copyTM=True)
                 newTi.setAcquisition(tiltImage.getAcquisition())
                 newTi.setLocation(i, (os.path.join(extraPrefix,
                                                    tiltImage.parseFileName())))

--- a/imod/protocols/protocol_excludeViews.py
+++ b/imod/protocols/protocol_excludeViews.py
@@ -157,18 +157,16 @@ class ProtImodExcludeViews(ProtImodBase):
 
         excludedViews = self.getExcludedViews(ts)
 
+        i = 1
         for index, tiltImage in enumerate(ts):
-            stackIndex = index + 1
-            if stackIndex not in excludedViews:
+            if (index + 1) not in excludedViews:
                 newTi = tomoObj.TiltImage()
                 newTi.copyInfo(tiltImage, copyId=True, copyTM=True)
                 newTi.setAcquisition(tiltImage.getAcquisition())
-                newTi.setLocation(stackIndex,
-                                  (os.path.join(extraPrefix,
-                                                tiltImage.parseFileName())))
+                newTi.setLocation(i, (os.path.join(extraPrefix,
+                                                   tiltImage.parseFileName())))
                 newTs.append(newTi)
-            else:
-                self.info("%s excluded from %s." % (stackIndex, tsId))
+                i += 1
         newTs.write(properties=False)
 
         output.update(newTs)

--- a/imod/protocols/protocol_fiducialAlignment.py
+++ b/imod/protocols/protocol_fiducialAlignment.py
@@ -29,7 +29,6 @@ import numpy as np
 
 from pyworkflow import BETA
 import pyworkflow.protocol.params as params
-import pyworkflow.utils.path as path
 from pwem.objects import Transform
 from pwem.emlib.image import ImageHandler
 from pyworkflow.object import Set
@@ -144,7 +143,6 @@ class ProtImodFiducialAlignment(ProtImodBase):
                       default=5,
                       condition='rotationSolutionType==2',
                       label='Group size',
-                      expertLevel=params.LEVEL_ADVANCED,
                       help='Size of the rotation group')
 
         form.addParam('magnificationSolutionType',
@@ -162,7 +160,6 @@ class ProtImodFiducialAlignment(ProtImodBase):
                       default=4,
                       condition='magnificationSolutionType==1',
                       label='Group size',
-                      expertLevel=params.LEVEL_ADVANCED,
                       help='Size of the magnification group')
 
         form.addParam('tiltAngleSolutionType',
@@ -179,7 +176,6 @@ class ProtImodFiducialAlignment(ProtImodBase):
                       default=5,
                       condition='tiltAngleSolutionType==1',
                       label='Group size',
-                      expertLevel=params.LEVEL_ADVANCED,
                       help='Size of the tilt angle group')
 
         form.addParam('distortionSolutionType',
@@ -195,7 +191,6 @@ class ProtImodFiducialAlignment(ProtImodBase):
                       default=7,
                       condition='distortionSolutionType==1',
                       label='X stretch group size',
-                      expertLevel=params.LEVEL_ADVANCED,
                       help='Basic grouping size for X stretch')
 
         form.addParam('skewGroupSize',
@@ -203,7 +198,6 @@ class ProtImodFiducialAlignment(ProtImodBase):
                       default=11,
                       condition='tiltAngleSolutionType==1 or tiltAngleSolutionType==2',
                       label='Skew group size',
-                      expertLevel=params.LEVEL_ADVANCED,
                       help='Size of the skew group')
 
         form.addSection('Erase gold beads')
@@ -227,7 +221,7 @@ class ProtImodFiducialAlignment(ProtImodBase):
         groupEraseGoldBeads.addParam('betterRadius',  # actually diameter
                                      params.IntParam,
                                      default=18,
-                                     label='Bead diameter (pixels)',
+                                     label='Bead diameter (px)',
                                      help="For circle objects, this entry "
                                           "specifies a radius to use for points "
                                           "without an individual point size "
@@ -632,37 +626,12 @@ class ProtImodFiducialAlignment(ProtImodBase):
 
         firstItem = ts.getFirstItem()
 
-        # Move interpolated tilt-series to tmp folder and generate a
-        # new one with the gold beads erased back in the
-        # extra folder
-        path.moveFile(os.path.join(extraPrefix, ts.getFirstItem().parseFileName()),
-                      os.path.join(tmpPrefix, ts.getFirstItem().parseFileName()))
-
-        # Generate interpolated model
-        paramsImodtrans = {
-            'inputFile': os.path.join(extraPrefix,
-                                      firstItem.parseFileName(suffix="_noGaps",
-                                                              extension=".fid")),
-            'outputFile': os.path.join(extraPrefix,
-                                       firstItem.parseFileName(suffix="_noGaps_ali",
-                                                               extension=".fid")),
-            'transformFile': os.path.join(extraPrefix,
-                                          firstItem.parseFileName(suffix="_fid",
-                                                                  extension=".xf"))
-        }
-
-        argsImodtrans = "-2 %(transformFile)s " \
-                        "%(inputFile)s " \
-                        "%(outputFile)s "
-
-        Plugin.runImod(self, 'imodtrans', argsImodtrans % paramsImodtrans)
-
-        # Erase gold beads
+        # Erase gold beads on aligned stack
         paramsCcderaser = {
             'inputFile': os.path.join(tmpPrefix, firstItem.parseFileName()),
             'outputFile': os.path.join(extraPrefix, firstItem.parseFileName()),
             'modelFile': os.path.join(extraPrefix,
-                                      firstItem.parseFileName(suffix="_noGaps_ali",
+                                      firstItem.parseFileName(suffix="_noGaps",
                                                               extension=".fid")),
             'betterRadius': self.betterRadius.get() / 2,
             'polynomialOrder': 0,
@@ -676,7 +645,9 @@ class ProtImodFiducialAlignment(ProtImodBase):
                         "-PolynomialOrder %(polynomialOrder)d " \
                         "-CircleObjects %(circleObjects)s " \
                         "-MergePatches 1 " \
-                        "-ExcludeAdjacent"
+                        "-ExcludeAdjacent " \
+                        "-SkipTurnedOffPoints 1 " \
+                        "-ExpandCircleIterations 3 "
 
         Plugin.runImod(self, 'ccderaser', argsCcderaser % paramsCcderaser)
 

--- a/imod/protocols/protocol_fiducialAlignment.py
+++ b/imod/protocols/protocol_fiducialAlignment.py
@@ -568,11 +568,11 @@ class ProtImodFiducialAlignment(ProtImodBase):
             # Check if rotation angle is greater than 45º. If so, swap x
             # and y dimensions to adapt output image sizes to
             # the final sample disposition.
-            if rotationAngleAvg > 45 or rotationAngleAvg < -45:
+            if 45 < abs(rotationAngleAvg) < 135:
                 paramsAlignment.update({
                     'size': "%d,%d" %
-                            (firstItem.getYDim() / int(self.binning.get()),
-                             firstItem.getXDim() / int(self.binning.get()))
+                            (firstItem.getYDim() // self.binning.get(),
+                             firstItem.getXDim() // self.binning.get())
                 })
 
                 argsAlignment += " -size %(size)s "

--- a/imod/protocols/protocol_goldBeadPicker3d.py
+++ b/imod/protocols/protocol_goldBeadPicker3d.py
@@ -78,7 +78,8 @@ class ProtImodGoldBeadPicker3d(ProtImodBase):
 
         form.addParam('minRelativeStrength',
                       params.FloatParam,
-                      label='Minimum relative Strength',
+                      expertLevel=params.LEVEL_ADVANCED,
+                      label='Minimum relative strength',
                       default=0.05,
                       help='Minimum relative peak strength for keeping a '
                            'peak in the analysis.  The square root of the '
@@ -94,6 +95,7 @@ class ProtImodGoldBeadPicker3d(ProtImodBase):
 
         form.addParam('minSpacing',
                       params.FloatParam,
+                      expertLevel=params.LEVEL_ADVANCED,
                       label='Minimum spacing',
                       default=0.9,
                       help='Minimum spacing between peaks as a fraction of '


### PR DESCRIPTION
- Erase gold option now works for fid. alignment protocol (close #146 )
- fix wrong output file index numbers in the exclude views protocol, also do not copy objId
- fix rotation angle range for swapping x/y for newstack
- do not copy objId for apply TM protocol when excluding views
- fix output size in apply TM protocol
- add a warning for ctf corr. protocol if inputting ts with no alignment
- remove ts interpolation before estimating ctf