### PR TITLE
Gs fixes6

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,15 @@
 3.1:
+- remove displayAll button from set viewer as it seems to be not practical to open all items at once (close #141)
+- change etomo naming style to mrc (close #153)
+- output xtilt file from fid alignment
+- rename fid alignment output to align.log and parse it with imod tools
+- add beadtrack step  with current model as seed (close #160)
+- refactor viewers:
+   - remove ImodSetOfLandmarkModelsView, ImodSetOfTomogramsView, ImodSetView
+   - remove displayAllButton
+   - update etomoviewer for new naming style
+   - show tilt angles in 3dmod viewer (close #161 )
+   - fix saved3DCoord etomo output display
 - fix rotation angle calculation for newstack operation
 - remove transformation step from imod ctf estimation (ctf is estimated on raw ts stack)
 - fix rotation angle range for swapping x/y for newstack

--- a/imod/protocols/protocol_applyTransformationMatrix.py
+++ b/imod/protocols/protocol_applyTransformationMatrix.py
@@ -85,16 +85,15 @@ class ProtImodApplyTransformationMatrix(ProtImodBase):
     def computeAlignmentStep(self, tsObjId):
         ts = self.inputSetOfTiltSeries.get()[tsObjId]
         tsId = ts.getTsId()
-
         extraPrefix = self._getExtraPath(tsId)
-
         firstItem = ts.getFirstItem()
+        binning = int(self.binning.get())
 
         paramsAlignment = {
             'input': firstItem.getFileName(),
             'output': os.path.join(extraPrefix, firstItem.parseFileName()),
             'xform': os.path.join(extraPrefix, firstItem.parseFileName(extension=".xf")),
-            'bin': int(self.binning.get()),
+            'bin': binning,
             'imagebinned': 1.0
         }
 
@@ -112,8 +111,8 @@ class ProtImodApplyTransformationMatrix(ProtImodBase):
         # the final sample disposition.
         if 45 < abs(rotationAngle) < 135:
             paramsAlignment.update({
-                'size': "%d,%d" % (firstItem.getYDim() // self.binning.get(),
-                                   firstItem.getXDim() // self.binning.get())
+                'size': "%d,%d" % (round(firstItem.getYDim() / binning),
+                                   round(firstItem.getXDim() / binning))
             })
 
             argsAlignment += "-size %(size)s "
@@ -129,15 +128,15 @@ class ProtImodApplyTransformationMatrix(ProtImodBase):
 
         ts = self.inputSetOfTiltSeries.get()[tsObjId]
         tsId = ts.getTsId()
-
         extraPrefix = self._getExtraPath(tsId)
+        binning = int(self.binning.get())
 
         newTs = TiltSeries(tsId=tsId)
         newTs.copyInfo(ts)
         output.append(newTs)
 
-        if self.binning > 1:
-            newTs.setSamplingRate(ts.getSamplingRate() * int(self.binning.get()))
+        if binning > 1:
+            newTs.setSamplingRate(ts.getSamplingRate() * binning)
 
         index = 1
         for tiltImage in ts:
@@ -147,8 +146,8 @@ class ProtImodApplyTransformationMatrix(ProtImodBase):
                 newTi.setAcquisition(tiltImage.getAcquisition())
                 newTi.setLocation(index, (os.path.join(extraPrefix, tiltImage.parseFileName())))
                 index += 1
-                if self.binning > 1:
-                    newTi.setSamplingRate(tiltImage.getSamplingRate() * int(self.binning.get()))
+                if binning > 1:
+                    newTi.setSamplingRate(tiltImage.getSamplingRate() * binning)
                 newTs.append(newTi)
 
         ih = ImageHandler()

--- a/imod/protocols/protocol_base.py
+++ b/imod/protocols/protocol_base.py
@@ -142,18 +142,17 @@ class ProtImodBase(ProtTomoImportFiles, EMProtocol, ProtTomoBase):
 
                     argsAlignment += "-size %(size)s "
 
-                self.info("Interpolating tilt series %s with imod." % tsId)
+                self.info("Interpolating tilt series %s with imod" % tsId)
                 Plugin.runImod(self, 'newstack', argsAlignment % paramsAlignment)
 
             else:
-                self.info("Linking tilt series %s. Nothing to interpolate." % tsId)
-                path.createLink(firstItem.getLocation()[1], outputTsFileName)
+                self.info("Linking tilt series %s" % tsId)
+                path.createLink(firstItem.getFileName(), outputTsFileName)
 
         # Use Xmipp interpolation via Scipion
         else:
-            self.info("Interpolating tilt series %s with emlib." % tsId)
+            self.info("Interpolating tilt series %s with emlib" % tsId)
             ts.applyTransform(outputTsFileName)
-
 
         self.info("Tilt series %s available for processing at %s." % (tsId, outputTsFileName))
 
@@ -162,7 +161,6 @@ class ProtImodBase(ProtTomoImportFiles, EMProtocol, ProtTomoBase):
             angleFilePath = os.path.join(tmpPrefix,
                                          firstItem.parseFileName(extension=".tlt"))
             ts.generateTltFile(angleFilePath)
-
 
     # --------------------------- OUTPUT functions ----------------------------
     def getOutputSetOfTiltSeries(self, inputSet, binning=1):

--- a/imod/protocols/protocol_base.py
+++ b/imod/protocols/protocol_base.py
@@ -82,7 +82,8 @@ class ProtImodBase(ProtTomoImportFiles, EMProtocol, ProtTomoBase):
 
         :param tsObjId: Tilt series identifier
         :param generateAngleFile:  Boolean(True) to generate IMOD angle file
-        :param imodInterpolation: Boolean (True) to interpolate the tilt series with imod in case there is a TM.
+        :param imodInterpolation: Boolean (True) to interpolate the tilt series with
+                                  imod in case there is a TM.
                                   Pass None to cancel interpolation.
         :return:
         """
@@ -117,30 +118,10 @@ class ProtImodBase(ProtTomoImportFiles, EMProtocol, ProtTomoBase):
                                                 firstItem.parseFileName(extension=".xf"))
                 utils.formatTransformFile(ts, outputTmFileName)
 
-                # Apply interpolation
-                paramsAlignment = {
-                    'input': firstItem.getFileName(),
-                    'output': outputTsFileName,
-                    'xform': os.path.join(tmpPrefix,
-                                          firstItem.parseFileName(extension=".xf")),
-                }
-
-                argsAlignment = "-input %(input)s " \
-                                "-output %(output)s " \
-                                "-xform %(xform)s " \
-                                "-taper 1,1 "
-
-                rotationAngle = ts.getAcquisition().getTiltAxisAngle()
-
-                # Check if rotation angle is greater than 45º. If so,
-                # swap x and y dimensions to adapt output image sizes to
-                # the final sample disposition.
-                if 45 < abs(rotationAngle) < 135:
-                    paramsAlignment.update({
-                        'size': "%d,%d" % (firstItem.getYDim(), firstItem.getXDim())
-                    })
-
-                    argsAlignment += "-size %(size)s "
+                argsAlignment, paramsAlignment = self.getBasicNewstackParams(ts,
+                                                                             outputTsFileName,
+                                                                             xfFile=outputTmFileName,
+                                                                             firstItem=firstItem)
 
                 self.info("Interpolating tilt series %s with imod" % tsId)
                 Plugin.runImod(self, 'newstack', argsAlignment % paramsAlignment)
@@ -161,6 +142,52 @@ class ProtImodBase(ProtTomoImportFiles, EMProtocol, ProtTomoBase):
             angleFilePath = os.path.join(tmpPrefix,
                                          firstItem.parseFileName(extension=".tlt"))
             ts.generateTltFile(angleFilePath)
+
+    def getBasicNewstackParams(self, ts, outputTsFileName, inputTsFileName=None,
+                               xfFile=None, firstItem=None, binning=1):
+        """ Returns basic newstack arguments
+        
+        :param ts: Title Series object
+        :param outputTsFileName: tilt series output file name after newstack
+        :param inputTsFileName: Input tilt series file name. Default to firsItem.getFilename()
+        :param xfFile: xf file name, if passed, alignment will be generated and used
+        :param firstItem: Optional, otherwise it will be taken from ts
+        :param binning: Default to 1. to apply to output size
+        
+        """
+        
+        if firstItem is None:
+            firstItem = ts.getFirstItem()
+
+        if inputTsFileName is None:
+            inputTsFileName = firstItem.getFileName()
+
+        # Apply interpolation
+        paramsAlignment = {
+            'input': inputTsFileName,
+            'output': outputTsFileName,
+        }
+        argsAlignment = "-input %(input)s " \
+                        "-output %(output)s " \
+                        "-taper 1,1 "
+
+        if xfFile is not None:
+            paramsAlignment['xform'] = xfFile
+            argsAlignment += "-xform %(xform)s "
+
+        rotationAngle = ts.getAcquisition().getTiltAxisAngle()
+        # Check if rotation angle is greater than 45º. If so,
+        # swap x and y dimensions to adapt output image sizes to
+        # the final sample disposition.
+        if 45 < abs(rotationAngle) < 135:
+            paramsAlignment.update({
+                'size': "%d,%d" % (int(firstItem.getYDim()/binning),
+                                   int(firstItem.getXDim()/binning))
+            })
+
+            argsAlignment += "-size %(size)s "
+
+        return argsAlignment, paramsAlignment
 
     # --------------------------- OUTPUT functions ----------------------------
     def getOutputSetOfTiltSeries(self, inputSet, binning=1):

--- a/imod/protocols/protocol_ctfCorrection.py
+++ b/imod/protocols/protocol_ctfCorrection.py
@@ -134,6 +134,10 @@ class ProtImodCtfCorrection(ProtImodBase):
         self._insertFunctionStep(self.closeOutputSetsStep)
 
     # --------------------------- STEPS functions -----------------------------
+    def convertInputStep(self, tsObjId):
+        # Considering swapXY is required to make tilt axis vertical
+        super().convertInputStep(tsObjId, doSwap=True)
+
     def generateDefocusFile(self, tsObjId):
         ts = self.inputSetOfTiltSeries.get()[tsObjId]
         tsId = ts.getTsId()

--- a/imod/protocols/protocol_ctfEstimation_automatic.py
+++ b/imod/protocols/protocol_ctfEstimation_automatic.py
@@ -344,7 +344,6 @@ class ProtImodAutomaticCtfEstimation(ProtImodBase):
 
             paramsCtfPlotter['expectedDefocus'] = float(defocus)
 
-
         argsCtfPlotter = "-InputStack %(inputStack)s " \
                          "-AngleFile %(angleFile)s " \
                          "-DefocusFile %(defocusFile)s " \

--- a/imod/protocols/protocol_ctfEstimation_manual.py
+++ b/imod/protocols/protocol_ctfEstimation_manual.py
@@ -60,7 +60,7 @@ class ProtImodManualCtfEstimation(ProtImodAutomaticCtfEstimation):
         from imod.viewers import ImodGenericViewer
         self.inputSetOfTiltSeries = self._getSetOfTiltSeries()
         view = ImodGenericViewer(None, self, self.inputSetOfTiltSeries,
-                                 displayAllButton=False, createSetButton=True,
+                                 createSetButton=True,
                                  isInteractive=True,
                                  itemDoubleClick=True)
         view.show()

--- a/imod/protocols/protocol_etomo.py
+++ b/imod/protocols/protocol_etomo.py
@@ -75,6 +75,14 @@ class ProtImodEtomo(ProtImodBase):
                       label='Fiducial markers diameter (nm)',
                       help='Diameter of gold beads in nanometers.')
 
+        form.addParam('applyAlignment',
+                      params.BooleanParam,
+                      default=False,
+                      expertLevel=params.LEVEL_ADVANCED,
+                      label='Apply transformation matrix?',
+                      help='Apply the transformation matrix if input'
+                           'tilt series have it.')
+
         form.addParallelSection(threads=1, mpi=0)
 
     # -------------------------- INSERT steps functions -----------------------
@@ -119,8 +127,12 @@ class ProtImodEtomo(ProtImodBase):
 
         outputTsFileName = self.getFilePath(ts, extension=".mrc")
 
-        """Apply the transformation form the input tilt-series"""
-        ts.applyTransform(outputTsFileName)
+        """Apply the transformation from the input tilt-series"""
+        if self.applyAlignment:
+            ts.applyTransform(outputTsFileName)
+        else:
+            path.createAbsLink(os.path.abspath(firstItem.getFileName()),
+                               outputTsFileName)
 
         """Generate angle file"""
         angleFilePath = self.getFilePath(ts, extension=".rawtlt")
@@ -302,7 +314,7 @@ class ProtImodEtomo(ProtImodBase):
             """Output set of coordinates 3D (associated to the aligned tilt-series)"""
             coordFilePath = self.getFilePath(ts, suffix='fid', extension=".xyz")
 
-            if os.path.exists(coordFilePath):
+            if os.path.exists(coordFilePath) and outputAliSetOfTiltSeries is not None:
                 if setOfTSCoords is None:
                     setOfTSCoords = tomoObj.SetOfTiltSeriesCoordinates.create(self._getPath(),
                                                                               suffix='Fiducials3D')

--- a/imod/protocols/protocol_fiducialModel.py
+++ b/imod/protocols/protocol_fiducialModel.py
@@ -161,6 +161,7 @@ class ProtImodFiducialModel(ProtImodBase):
             try:
                 func(self, tsId)
             except Exception as e:
+                self.error("Some error occurred calling %s with TS id %s: %s" % (func.__name__, tsId, e))
                 self._failedTs.append(tsId)
 
         return wrapper
@@ -327,7 +328,7 @@ class ProtImodFiducialModel(ProtImodBase):
         if len(excludedViews):
             argsBeadtrack += f"-SkipViews {','.join(excludedViews)} "
 
-        if firstItem.hasAlignment():
+        if firstItem.hasTransform():
             XfFileName = os.path.join(tmpPrefix,
                                       firstItem.parseFileName(extension=".xf"))
             argsBeadtrack += f"-prexf {XfFileName} "
@@ -478,9 +479,10 @@ class ProtImodFiducialModel(ProtImodBase):
         extraPrefix = self._getExtraPath(tsId)
         tmpPrefix = self._getTmpPath(tsId)
 
+        firstItem = ts.getFirstItem()
         trackFilePath = os.path.join(extraPrefix,
-                                     ts.getFirstItem().parseFileName(suffix="_track",
-                                                                     extension=".com"))
+                                     firstItem.parseFileName(suffix="_track",
+                                                             extension=".com"))
 
         template = """# Command file for running BEADTRACK
 #
@@ -556,9 +558,9 @@ ScalableSigmaForSobel   %(scalableSigmaForSobelFilter)f
         if len(excludedViews):
             template += f"SkipViews {','.join(excludedViews)}"
 
-        if ts.getFirstItem().hasAlignment():
+        if firstItem.hasTransform():
             XfFileName = os.path.join(tmpPrefix,
-                                      ts.getFirstItem().parseFileName(extension=".xf"))
+                                      firstItem.parseFileName(extension=".xf"))
             template += f"PrealignTransformFile {XfFileName}"
 
         with open(trackFilePath, 'w') as f:

--- a/imod/protocols/protocol_goldBeadPicker3d.py
+++ b/imod/protocols/protocol_goldBeadPicker3d.py
@@ -138,7 +138,7 @@ class ProtImodGoldBeadPicker3d(ProtImodBase):
 
         """ Run findbeads3d IMOD program """
         paramsFindbeads3d = {
-            'inputFile': tomo.getFilename(),
+            'inputFile': tomo.getFileName(),
             'outputFile': os.path.join(extraPrefix, "%s.mod" % fileName),
             'beadSize': self.beadDiameter.get(),
             'minRelativeStrength': self.minRelativeStrength.get(),
@@ -159,7 +159,7 @@ class ProtImodGoldBeadPicker3d(ProtImodBase):
 
     def convertModelToCoordinatesStep(self, tsObjId):
         tomo = self.inputSetOfTomograms.get()[tsObjId]
-        location = tomo.getFilename()
+        location = tomo.getFileName()
         fileName, _ = os.path.splitext(location)
 
         extraPrefix = self._getExtraPath(os.path.basename(fileName))
@@ -177,7 +177,7 @@ class ProtImodGoldBeadPicker3d(ProtImodBase):
 
     def createOutputStep(self, tsObjId):
         tomo = self.inputSetOfTomograms.get()[tsObjId]
-        location = tomo.getFilename()
+        location = tomo.getFileName()
         fileName, _ = os.path.splitext(location)
 
         extraPrefix = self._getExtraPath(os.path.basename(fileName))

--- a/imod/protocols/protocol_goldBeadPicker3d.py
+++ b/imod/protocols/protocol_goldBeadPicker3d.py
@@ -28,7 +28,7 @@ import os
 
 from pyworkflow import BETA
 import pyworkflow.protocol.params as params
-from pyworkflow.utils import path
+from pyworkflow.utils import path, removeBaseExt
 from pyworkflow.object import Set
 import tomo.objects as tomoObj
 import tomo.constants as constants
@@ -132,17 +132,14 @@ class ProtImodGoldBeadPicker3d(ProtImodBase):
     # --------------------------- STEPS functions -----------------------------
     def pickGoldBeadsStep(self, tsObjId):
         tomo = self.inputSetOfTomograms.get()[tsObjId]
-        location = tomo.getLocation()[1]
-        fileName, _ = os.path.splitext(location)
-
-        extraPrefix = self._getExtraPath(os.path.basename(fileName))
+        fileName = removeBaseExt(tomo.getFileName())
+        extraPrefix = self._getExtraPath(fileName)
         path.makePath(extraPrefix)
 
         """ Run findbeads3d IMOD program """
         paramsFindbeads3d = {
-            'inputFile': location,
-            'outputFile': os.path.join(extraPrefix,
-                                       "%s.mod" % os.path.basename(fileName)),
+            'inputFile': tomo.getFilename(),
+            'outputFile': os.path.join(extraPrefix, "%s.mod" % fileName),
             'beadSize': self.beadDiameter.get(),
             'minRelativeStrength': self.minRelativeStrength.get(),
             'minSpacing': self.minSpacing.get(),
@@ -162,7 +159,7 @@ class ProtImodGoldBeadPicker3d(ProtImodBase):
 
     def convertModelToCoordinatesStep(self, tsObjId):
         tomo = self.inputSetOfTomograms.get()[tsObjId]
-        location = tomo.getLocation()[1]
+        location = tomo.getFilename()
         fileName, _ = os.path.splitext(location)
 
         extraPrefix = self._getExtraPath(os.path.basename(fileName))
@@ -180,7 +177,7 @@ class ProtImodGoldBeadPicker3d(ProtImodBase):
 
     def createOutputStep(self, tsObjId):
         tomo = self.inputSetOfTomograms.get()[tsObjId]
-        location = tomo.getLocation()[1]
+        location = tomo.getFilename()
         fileName, _ = os.path.splitext(location)
 
         extraPrefix = self._getExtraPath(os.path.basename(fileName))

--- a/imod/protocols/protocol_tomoNormalization.py
+++ b/imod/protocols/protocol_tomoNormalization.py
@@ -193,7 +193,7 @@ class ProtImodTomoNormalization(ProtImodBase):
     # --------------------------- STEPS functions -----------------------------
     def generateOutputStackStep(self, tsObjId):
         tomo = self.inputSetOfTomograms.get()[tsObjId]
-        location = tomo.getFilename()
+        location = tomo.getFileName()
         fileName, fileExtension = os.path.splitext(location)
 
         extraPrefix = self._getExtraPath(os.path.basename(fileName))

--- a/imod/protocols/protocol_tomoNormalization.py
+++ b/imod/protocols/protocol_tomoNormalization.py
@@ -193,7 +193,7 @@ class ProtImodTomoNormalization(ProtImodBase):
     # --------------------------- STEPS functions -----------------------------
     def generateOutputStackStep(self, tsObjId):
         tomo = self.inputSetOfTomograms.get()[tsObjId]
-        location = tomo.getLocation()[1]
+        location = tomo.getFilename()
         fileName, fileExtension = os.path.splitext(location)
 
         extraPrefix = self._getExtraPath(os.path.basename(fileName))

--- a/imod/protocols/protocol_tomoReconstruction.py
+++ b/imod/protocols/protocol_tomoReconstruction.py
@@ -170,6 +170,10 @@ class ProtImodTomoReconstruction(ProtImodBase):
         self._insertFunctionStep(self.closeOutputSetsStep)
 
     # --------------------------- STEPS functions -----------------------------
+    def convertInputStep(self, tsObjId):
+        # Considering swapXY is required to make tilt axis vertical
+        super().convertInputStep(tsObjId, doSwap=True)
+
     def computeReconstructionStep(self, tsObjId):
         ts = self.inputSetOfTiltSeries.get()[tsObjId]
         tsId = ts.getTsId()

--- a/imod/protocols/protocol_tsNormalization.py
+++ b/imod/protocols/protocol_tsNormalization.py
@@ -33,6 +33,7 @@ import tomo.objects as tomoObj
 
 from .. import Plugin
 from .protocol_base import ProtImodBase
+from ..utils import formatTransformFile
 
 
 class ProtImodTSNormalization(ProtImodBase):
@@ -56,12 +57,18 @@ class ProtImodTSNormalization(ProtImodBase):
 
         form.addParam('binning',
                       params.FloatParam,
-                      default=1.0,
+                      default=1,
                       label='Binning',
                       important=True,
                       help='Binning to be applied to the normalized tilt-series '
                            'in IMOD convention. Images will be binned by the '
                            'given factor. Must be an integer bigger than 1')
+
+        form.addParam('applyAlignment',
+                      params.BooleanParam,
+                      default=False,
+                      label='Apply transformation matrix',
+                      help='Apply the tilt series transformation matrix if tilt series have them')
 
         form.addParam('floatDensities',
                       params.EnumParam,
@@ -185,12 +192,16 @@ class ProtImodTSNormalization(ProtImodBase):
     # -------------------------- INSERT steps functions -----------------------
     def _insertAllSteps(self):
         for ts in self.inputSetOfTiltSeries.get():
-            self._insertFunctionStep(self.convertInputStep, ts.getObjId(),
-                                     generateAngleFile=False)
+            self._insertFunctionStep(self.convertInputStep, ts.getObjId())
             self._insertFunctionStep(self.generateOutputStackStep, ts.getObjId())
         self._insertFunctionStep(self.closeOutputSetsStep)
 
     # --------------------------- STEPS functions -----------------------------
+    def convertInputStep(self, tsObjId):
+        # Interpolation will be done in the generateOutputStep
+        super().convertInputStep(tsObjId, imodInterpolation=None,
+                                 generateAngleFile=False)
+
     def generateOutputStackStep(self, tsObjId):
         output = self.getOutputSetOfTiltSeries(self.inputSetOfTiltSeries.get(),
                                                self.binning.get())
@@ -200,20 +211,32 @@ class ProtImodTSNormalization(ProtImodBase):
 
         extraPrefix = self._getExtraPath(tsId)
         tmpPrefix = self._getTmpPath(tsId)
+        firstItem = ts.getFirstItem()
 
-        paramsNewstack = {
-            'input': os.path.join(tmpPrefix, ts.getFirstItem().parseFileName()),
-            'output': os.path.join(extraPrefix, ts.getFirstItem().parseFileName()),
-            'bin': int(self.binning.get()),
+        xfFile = None
+
+        if self.applyAlignment.get() and ts.hasAlignment():
+            xfFile = os.path.join(tmpPrefix, firstItem.parseFileName(extension=".xf"))
+            formatTransformFile(ts, xfFile)
+
+        binning = int(self.binning.get())
+
+        argsNewstack, paramsNewstack = self.getBasicNewstackParams(ts,
+                                                                   os.path.join(extraPrefix, firstItem.parseFileName()),
+                                                                   inputTsFileName=os.path.join(tmpPrefix, firstItem.parseFileName()),
+                                                                   xfFile=xfFile,
+                                                                   firstItem=firstItem,
+                                                                   binning=binning,
+                                                                   )
+        paramsNewstack.update({
+            'bin': binning,
             'imagebinned': 1.0,
             'antialias': self.antialias.get() + 1
-        }
+        })
 
-        argsNewstack = "-input %(input)s " \
-                       "-output %(output)s " \
-                       "-bin %(bin)d " \
-                       "-antialias %(antialias)d " \
-                       "-imagebinned %(imagebinned)s "
+        argsNewstack += "-bin %(bin)d " \
+                        "-antialias %(antialias)d " \
+                        "-imagebinned %(imagebinned)s "
 
         if self.floatDensities.get() != 0:
             argsNewstack += " -FloatDensities " + str(self.floatDensities.get())
@@ -240,19 +263,24 @@ class ProtImodTSNormalization(ProtImodBase):
         newTs.copyInfo(ts)
         output.append(newTs)
 
-        if self.binning > 1:
+        if binning > 1:
             newTs.setSamplingRate(ts.getSamplingRate() * int(self.binning.get()))
 
         for index, tiltImage in enumerate(ts):
             newTi = tomoObj.TiltImage()
             newTi.copyInfo(tiltImage, copyId=True, copyTM=True)
-            if tiltImage.hasTransform():
+
+            # Tranformation matrix
+            if tiltImage.hasTransform() and not self.applyAlignment.get():
                 newTi = self.updateTM(newTi)
+            else:
+                newTi.setTransform(None)
+
             newTi.setAcquisition(tiltImage.getAcquisition())
             newTi.setLocation(index + 1,
                               (os.path.join(extraPrefix, tiltImage.parseFileName())))
-            if self.binning > 1:
-                newTi.setSamplingRate(tiltImage.getSamplingRate() * int(self.binning.get()))
+            if binning > 1:
+                newTi.setSamplingRate(tiltImage.getSamplingRate() * binning)
             newTs.append(newTi)
 
         ih = ImageHandler()

--- a/imod/protocols/protocol_xCorrPrealignment.py
+++ b/imod/protocols/protocol_xCorrPrealignment.py
@@ -175,10 +175,10 @@ class ProtImodXcorrPrealignment(ProtImodBase):
                     "-output %(output)s " \
                     "-tiltfile %(tiltfile)s " \
                     "-RotationAngle %(rotationAngle).2f " \
-                    "-FilterSigma1 %(filterSigma1)f " \
-                    "-FilterSigma2 %(filterSigma2)f " \
-                    "-FilterRadius1 %(filterRadius1)f " \
-                    "-FilterRadius2 %(filterRadius2)f "
+                    "-FilterSigma1 %(filterSigma1).3f " \
+                    "-FilterSigma2 %(filterSigma2).3f " \
+                    "-FilterRadius1 %(filterRadius1).3f " \
+                    "-FilterRadius2 %(filterRadius2).3f "
 
         if self.cumulativeCorr == 0:
             argsXcorr += "-CumulativeCorrelation "

--- a/imod/protocols/protocol_xRaysEraser.py
+++ b/imod/protocols/protocol_xRaysEraser.py
@@ -125,11 +125,11 @@ class ProtImodXraysEraser(ProtImodBase):
             'findPeaks': 1,
             'peakCriterion': self.peakCriterion.get(),
             'diffCriterion': self.diffCriterion.get(),
-            'growCriterion': 4,
-            'scanCriterion': 3,
+            'growCriterion': 4.,
+            'scanCriterion': 3.,
             'maximumRadius': self.maximumRadius.get(),
-            'giantCriterion': 12,
-            'extraLargeRadius': 8,
+            'giantCriterion': 12.,
+            'extraLargeRadius': 8.,
             'bigDiffCriterion': self.bigDiffCriterion.get(),
             'annulusWidth': 2.0,
             'xyScanSize': 100,
@@ -146,12 +146,12 @@ class ProtImodXraysEraser(ProtImodBase):
                         "-FindPeaks %(findPeaks)d " \
                         "-PeakCriterion %(peakCriterion).2f " \
                         "-DiffCriterion %(diffCriterion).2f " \
-                        "-GrowCriterion %(growCriterion)d " \
-                        "-ScanCriterion %(scanCriterion)d " \
+                        "-GrowCriterion %(growCriterion).2f " \
+                        "-ScanCriterion %(scanCriterion).2f " \
                         "-MaximumRadius %(maximumRadius).2f " \
-                        "-GiantCriterion %(giantCriterion)d " \
-                        "-ExtraLargeRadius %(extraLargeRadius)d " \
-                        "-BigDiffCriterion %(bigDiffCriterion)d " \
+                        "-GiantCriterion %(giantCriterion).2f " \
+                        "-ExtraLargeRadius %(extraLargeRadius).2f " \
+                        "-BigDiffCriterion %(bigDiffCriterion).2f " \
                         "-AnnulusWidth %(annulusWidth).2f " \
                         "-XYScanSize %(xyScanSize)d " \
                         "-EdgeExclusionWidth %(edgeExclusionWidth)d " \

--- a/imod/tests/test_protocols_imod.py
+++ b/imod/tests/test_protocols_imod.py
@@ -627,7 +627,7 @@ class TestImodReconstructionWorkflow(TestImodBase):
         output = self.protTomoNormalization.Tomograms
         self.assertSetSize(output, size=2)
 
-        location = self.protTomoNormalization.inputSetOfTomograms.get().getFirstItem().getFilename()
+        location = self.protTomoNormalization.inputSetOfTomograms.get().getFirstItem().getFileName()
         tomoId = pwutils.removeBaseExt(location)
 
         self.assertTrue(os.path.exists(os.path.join(self.protTomoNormalization._getExtraPath(tomoId),

--- a/imod/tests/test_protocols_imod.py
+++ b/imod/tests/test_protocols_imod.py
@@ -627,9 +627,8 @@ class TestImodReconstructionWorkflow(TestImodBase):
         output = self.protTomoNormalization.Tomograms
         self.assertSetSize(output, size=2)
 
-        location = self.protTomoNormalization.inputSetOfTomograms.get().getFirstItem().getLocation()[1]
-        fileName, _ = os.path.splitext(location)
-        tomoId = os.path.basename(fileName)
+        location = self.protTomoNormalization.inputSetOfTomograms.get().getFirstItem().getFilename()
+        tomoId = pwutils.removeBaseExt(location)
 
         self.assertTrue(os.path.exists(os.path.join(self.protTomoNormalization._getExtraPath(tomoId),
                                                     tomoId + ".mrc")))

--- a/imod/utils.py
+++ b/imod/utils.py
@@ -38,6 +38,7 @@ import pyworkflow.object as pwobj
 import pyworkflow.utils as pwutils
 from imod import Plugin
 
+
 def formatTransformFile(ts, transformFilePath):
     """ This method takes a tilt series and the output transformation file path
     and creates an IMOD-based transform
@@ -197,7 +198,7 @@ def generateIMODFidFile(protocol, landmarkModel):
 
         protocol.setStepsExecutor()
         Plugin.runImod(protocol, 'point2model',
-                            argsPoint2Model % paramsPoint2Model)
+                       argsPoint2Model % paramsPoint2Model)
 
     return fiducialModelGapPath
 
@@ -228,7 +229,6 @@ def formatAngleList(tltFilePath):
         tltText = f.read().splitlines()
         for line in tltText:
             angleList.append(float(line))
-    # angleList.reverse()
 
     return angleList
 
@@ -477,7 +477,7 @@ def refactorCTFDefocusPhaseShiftEstimationInfo(ctfInfoIMODTable):
 
     else:
         raise Exception("Misleading file format, CTF estimation with "
-                        "astigmatism and phase shift should be 6 columns "
+                        "defocus and phase shift should be 6 columns "
                         "long")
 
     return defocusUDict, phaseShiftDict
@@ -534,7 +534,7 @@ def refactorCTFDefocusAstigmatismPhaseShiftEstimationInfo(ctfInfoIMODTable):
                     phaseShiftDict[index] = [pwobj.Float(element[7])]
 
     else:
-        raise Exception("Misleading file format, CTF estiation with "
+        raise Exception("Misleading file format, CTF estimation with "
                         "astigmatism and phase shift should be 8 columns "
                         "long")
 
@@ -599,7 +599,7 @@ def refactorCTFDefocusAstigmatismPhaseShiftCutOnFreqEstimationInfo(ctfInfoIMODTa
                     cutOnFreqDict[index] = [pwobj.Float(element[8])]
 
     else:
-        raise Exception("Misleading file format, CTF estiation with "
+        raise Exception("Misleading file format, CTF estimation with "
                         "astigmatism, phase shift and cut-on frequency "
                         "should be 8 columns long")
 
@@ -662,7 +662,7 @@ def generateDefocusIMODFileFromObject(ctfTomoSeries, defocusFilePath,
 
         elif flag == 1:
             # Astigmatism estimation
-            logger.debug("Flag 1: Astigmatism estimtion.")
+            logger.debug("Flag 1: Astigmatism estimation.")
 
             defocusUDict = generateDefocusUDictionary(ctfTomoSeries)
             defocusVDict = generateDefocusVDictionary(ctfTomoSeries)

--- a/imod/viewers/viewers.py
+++ b/imod/viewers/viewers.py
@@ -122,6 +122,10 @@ class ImodObjectView(pwviewer.CommandView):
 
             cmd += f"-a {angleFilePath} -m {outputTSPath} {fidFileName}"
 
+        # A path called from the object browser
+        elif isinstance(obj, str):
+            cmd += f"{obj}"
+
         else:  # Tomogram
             cmd += f"{obj.getFileName()}"
 


### PR DESCRIPTION
- remove displayAll button from set viewer as it seems to be not practical to open all items at once (close #141)
- change etomo naming style to mrc (close #153)
- output xtilt file from fid alignment
- rename fid alignment output to align.log and parse it with imod tools
- add beadtrack step  with current model as seed (close #160)
- refactor viewers: 
   - remove ImodSetOfLandmarkModelsView, ImodSetOfTomogramsView, ImodSetView
   - remove displayAllButton
   - update etomoviewer for new naming style
   - show tilt angles in 3dmod viewer (close #161 )
   - fix saved3DCoord etomo output display