### PR TITLE
  - Reconstruction:

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,12 @@
+3.1.8:
+  - Reconstruction:
+     - tomoWidth added to specify a width when reconstructing
+     - Shift in Z is registered in tomogram origin
+
+  - Ctf correction: Allows different size of ctf set and ts set. Only paired (TS-CTF) ones will be processed
 3.1.7:
-    - Validate input alignment for TS preprocess protocol
-    - Fix: Xray erser when there is alignment.
+  - Validate input alignment for TS preprocess protocol
+  - Fix: Xray erser when there is alignment.
 3.1.6:
   icon added
   template added for automatic tilt series alignment
@@ -8,54 +14,54 @@
 3.1.4: set tilt axis to 0 if TS is aligned (reported by Bram Koster)
 3.1.3: fix installation: remove libjpeg62 check
 3.1.2:
-- Flag ts as interpolated in some cases
-- Imod protocols do not work, for now in streaming
+  - Flag ts as interpolated in some cases
+  - Imod protocols do not work, for now in streaming
 3.1:
-- remove displayAll button from set viewer as it seems to be not practical to open all items at once (close #141)
-- change etomo naming style to mrc (close #153)
-- output xtilt file from fid alignment
-- rename fid alignment output to align.log and parse it with imod tools
-- add beadtrack step  with current model as seed (close #160)
-- refactor viewers:
-   - remove ImodSetOfLandmarkModelsView, ImodSetOfTomogramsView, ImodSetView
-   - remove displayAllButton
-   - update etomoviewer for new naming style
-   - show tilt angles in 3dmod viewer (close #161 )
-   - fix saved3DCoord etomo output display
-- fix rotation angle calculation for newstack operation
-- remove transformation step from imod ctf estimation (ctf is estimated on raw ts stack)
-- fix rotation angle range for swapping x/y for newstack
-- do not copy objId for apply TM protocol when excluding views
-- fix output size in apply TM protocol
-- fix wrong output file index numbers in the exclude views protocol
-- fix gold erasing option in the fid. alignment protocol
-- fix generating ctf output; hide some params from manual ctf protocol; do not run autofit for manual protocol
-- added xform file to ctfphaseflip to rotate astigmatism estimation and adjust for x-shifts for the image center
-- fix excluded views parsing from com files
-- rename "normalization" to "preprocess" protocols
-- handle excluded views properly (closes #137 , closes #147)
-- ctfplotter handles excluded views properly, output ctfs for such views have 0 values
-- fix failed ts generation in fid.alignment protocol
-- pep8 fixes, add pip-related files
-- mtffilter was missing pixelsize param, causing wrong filter being applied (always with 1A/px)
-- add antialias param to ts norm protocol
-- fix wrong default naming style for etomo
-- enable robust fitting for beadtracker
-- remove redundant updateDim calls
-- get acquisition from ts when creating a tomo
-- fix pixsize and dims for etomo outputs (closes #139)
-- fix beadtrack args to match copytomocoms script
-- always use antialias when binning a stack
-- two surfaces search is off in both protocols for consistency
-- bead radius default is 18px (good range for bin 4 and 10nm beads)
-- use sobel filter for bead centering for most cryo data
-- use lowpass for bead tracking
-- use adjustbeadsizes
-- trimvol -yz replaced by -rx, the first one flips the hand
-- add expandcircles to eraser
-- replace wrong dose file format for mtffilter
-- set output 3D coord size based on bead diameter
-- fix betterradius param in gold eraser tab of the fid alignment
-- add missing pix size in fid align
-- fix minpacing in gold picker
-- add missing taper arg for newstack
+  - remove displayAll button from set viewer as it seems to be not practical to open all items at once (close #141)
+  - change etomo naming style to mrc (close #153)
+  - output xtilt file from fid alignment
+  - rename fid alignment output to align.log and parse it with imod tools
+  - add beadtrack step  with current model as seed (close #160)
+  - refactor viewers:
+     - remove ImodSetOfLandmarkModelsView, ImodSetOfTomogramsView, ImodSetView
+     - remove displayAllButton
+     - update etomoviewer for new naming style
+     - show tilt angles in 3dmod viewer (close #161 )
+     - fix saved3DCoord etomo output display
+  - fix rotation angle calculation for newstack operation
+  - remove transformation step from imod ctf estimation (ctf is estimated on raw ts stack)
+  - fix rotation angle range for swapping x/y for newstack
+  - do not copy objId for apply TM protocol when excluding views
+  - fix output size in apply TM protocol
+  - fix wrong output file index numbers in the exclude views protocol
+  - fix gold erasing option in the fid. alignment protocol
+  - fix generating ctf output; hide some params from manual ctf protocol; do not run autofit for manual protocol
+  - added xform file to ctfphaseflip to rotate astigmatism estimation and adjust for x  -shifts for the image center
+  - fix excluded views parsing from com files
+  - rename "normalization" to "preprocess" protocols
+  - handle excluded views properly (closes #137 , closes #147)
+  - ctfplotter handles excluded views properly, output ctfs for such views have 0 values
+  - fix failed ts generation in fid.alignment protocol
+  - pep8 fixes, add pip  -related files
+  - mtffilter was missing pixelsize param, causing wrong filter being applied (always with 1A/px)
+  - add antialias param to ts norm protocol
+  - fix wrong default naming style for etomo
+  - enable robust fitting for beadtracker
+  - remove redundant updateDim calls
+  - get acquisition from ts when creating a tomo
+  - fix pixsize and dims for etomo outputs (closes #139)
+  - fix beadtrack args to match copytomocoms script
+  - always use antialias when binning a stack
+  - two surfaces search is off in both protocols for consistency
+  - bead radius default is 18px (good range for bin 4 and 10nm beads)
+  - use sobel filter for bead centering for most cryo data
+  - use lowpass for bead tracking
+  - use adjustbeadsizes
+  - trimvol -yz replaced by -rx, the first one flips the hand
+  - add expandcircles to eraser
+  - replace wrong dose file format for mtffilter
+  - set output 3D coord size based on bead diameter
+  - fix betterradius param in gold eraser tab of the fid alignment
+  - add missing pix size in fid align
+  - fix minpacing in gold picker
+  - add missing taper arg for newstack

--- a/imod/__init__.py
+++ b/imod/__init__.py
@@ -36,7 +36,7 @@ import pwem
 from .constants import IMOD_HOME, ETOMO_CMD, DEFAULT_VERSION, VERSIONS
 
 
-__version__ = '3.1.7'
+__version__ = '3.1.8'
 _logo = "icon.png"
 _references = ['Kremer1996', 'Mastronarde2017']
 

--- a/imod/protocols/protocol_ctfCorrection.py
+++ b/imod/protocols/protocol_ctfCorrection.py
@@ -262,16 +262,6 @@ class ProtImodCtfCorrection(ProtImodBase):
 
         return warnings
 
-    def _validate(self):
-        validateMsgs = []
-
-        if self.inputSetOfTiltSeries.get().getSize() != self.inputSetOfCtfTomoSeries.get().getSize():
-            validateMsgs.append("Input tilt-series and CTF tomo "
-                                "estimations must contain the "
-                                "same number of elements.")
-
-        return validateMsgs
-
     def _summary(self):
         summary = []
         if self.TiltSeries:

--- a/imod/protocols/protocol_tomoReconstruction.py
+++ b/imod/protocols/protocol_tomoReconstruction.py
@@ -61,7 +61,6 @@ class ProtImodTomoReconstruction(ProtImodBase):
                       default=1000,
                       label='Tomogram thickness (voxels)',
                       important=True,
-                      display=params.EnumParam.DISPLAY_HLIST,
                       help='Size in voxels of the tomogram in the z '
                            'axis (beam direction).')
 
@@ -69,18 +68,20 @@ class ProtImodTomoReconstruction(ProtImodBase):
                       params.FloatParam,
                       default=0,
                       label='Tomogram shift in X',
-                      display=params.EnumParam.DISPLAY_HLIST,
                       help='This entry allows one to shift the reconstructed '
                            'slice in X before it is output.  If the X shift '
                            'is positive, the slice will be shifted to the '
                            'right, and the output will contain the left part '
                            'of the whole potentially reconstructable area.')
-
+        form.addParam('tomoWidth',
+                      params.IntParam,
+                      default=0,
+                      label='Tomogram width (voxels)',
+                      help='Number of pixels to cut out in X, centered on the middle in X. Leave 0 for default X.')
         form.addParam('tomoShiftZ',
                       params.FloatParam,
                       default=0,
                       label='Tomogram shift in Z',
-                      display=params.EnumParam.DISPLAY_HLIST,
                       help='This entry allows one to shift the reconstructed '
                            'slice in Z before it is output. If the Z '
                            'shift is positive, the slice is shifted upward. '
@@ -91,7 +92,6 @@ class ProtImodTomoReconstruction(ProtImodBase):
                       params.FloatParam,
                       default=0,
                       label='Angle offset',
-                      display=params.EnumParam.DISPLAY_HLIST,
                       help='Apply an angle offset in degrees to all tilt '
                            'angles. This offset positively rotates the '
                            'reconstructed sections anticlockwise.')
@@ -100,7 +100,6 @@ class ProtImodTomoReconstruction(ProtImodBase):
                       params.FloatParam,
                       default=0,
                       label='Tilt axis offset',
-                      display=params.EnumParam.DISPLAY_HLIST,
                       help='Apply an offset to the tilt axis in a stack of '
                            'full-sized projection images, cutting the '
                            'X-axis at  NX/2. + offset instead of NX/2. The '
@@ -111,7 +110,6 @@ class ProtImodTomoReconstruction(ProtImodBase):
                       params.IntParam,
                       default=0,
                       label='Iterations of a SIRT-like equivalent filter',
-                      display=params.EnumParam.DISPLAY_HLIST,
                       expertLevel=params.LEVEL_ADVANCED,
                       help='Modify the radial filter to produce a '
                            'reconstruction equivalent to the one produced by '
@@ -223,10 +221,18 @@ class ProtImodTomoReconstruction(ProtImodBase):
 
         Plugin.runImod(self, 'tilt', argsTilt % paramsTilt)
 
+        def getArgs():
+            args = "-rx "
+
+            if self.tomoWidth.get():
+                args += " -nx %s" % self.tomoWidth.get()
+
+            return args
+
         paramsTrimVol = {
             'input': os.path.join(tmpPrefix, firstItem.parseFileName(extension=".rec")),
             'output': os.path.join(extraPrefix, firstItem.parseFileName(extension=".mrc")),
-            'options': "-rx "
+            'options': getArgs()
         }
 
         argsTrimvol = "%(options)s " \
@@ -251,6 +257,11 @@ class ProtImodTomoReconstruction(ProtImodBase):
         newTomogram.setSamplingRate(ts.getSamplingRate())
         # Set default tomogram origin
         newTomogram.setOrigin(newOrigin=None)
+        if self.tomoShiftZ.get():
+            x,y,z = newTomogram.getShiftsFromOrigin()
+            shiftZang= self.tomoShiftZ.get() * newTomogram.getSamplingRate()
+            newTomogram.setShiftsInOrigin(x=x,y=y,z=z+shiftZang)
+
         newTomogram.setAcquisition(ts.getAcquisition())
 
         output.append(newTomogram)


### PR DESCRIPTION
     - tomoWidth added to specify a width when reconstructing
     - Shift in Z is registered in tomogram origin

NOTE: Branch name is not descriptive.