### PR TITLE
Added option -SuperSampleFactor to tomo reconstruction protocol (tilt)

### DIFF
--- a/imod/protocols/protocol_tomoReconstruction.py
+++ b/imod/protocols/protocol_tomoReconstruction.py
@@ -106,6 +106,13 @@ class ProtImodTomoReconstruction(ProtImodBase):
                            'DELXX entry is optional and defaults to 0 '
                            'when omitted.')
 
+        form.addParam('superSampleFactor',
+                      params.IntParam,
+                      default=2,
+                      label='Super-sampling factor',
+                      expertLevel=params.LEVEL_ADVANCED,
+                      help='Compute slices in pixels smaller by this factor to reduce artifacts.')
+        
         form.addParam('fakeInteractionsSIRT',
                       params.IntParam,
                       default=0,
@@ -205,6 +212,7 @@ class ProtImodTomoReconstruction(ProtImodBase):
             'Radial': str(self.radialFirstParameter.get()) + "," + str(self.radialSecondParameter.get()),
             'Shift': str(self.tomoShiftX.get()) + "," + str(self.tomoShiftZ.get()),
             'Offset': str(self.angleOffset.get()) + "," + str(self.tiltAxisOffset.get()),
+            'SuperSampleFactor': self.superSampleFactor.get(),
         }
 
         argsTilt = "-InputProjections %(InputProjections)s " \
@@ -217,6 +225,7 @@ class ProtImodTomoReconstruction(ProtImodBase):
                    "-OFFSET %(Offset)s " \
                    "-MODE 1 " \
                    "-PERPENDICULAR " \
+                   "-SuperSampleFactor %(SuperSampleFactor)d " \
                    "-AdjustOrigin "
 
         if self.fakeInteractionsSIRT.get() != 0:


### PR DESCRIPTION
Hi,

I added the `-SuperSampleFactor` option to the IMOD tomo reconstruction protocol with a default value of 2. This option greatly mitigates interpolation artefacts in Fourier backprojection (see images below). If you want to keep the old behavior unchanged, feel free to set the default value to 1.

`-SuperSampleFactor 1` (old behavior):
![image](https://github.com/scipion-em/scipion-em-imod/assets/7696255/e9a439a4-7523-4d12-8d96-c0c0b0324c8a)

`-SuperSampleFactor 2` (new behavior):
![image](https://github.com/scipion-em/scipion-em-imod/assets/7696255/f6d7ed2b-f069-4d14-9494-e01040cec4a3)

Best wishes,
Ricardo
