### PR TITLE
bugfix for import ctf, set missing defocus flag

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,4 @@
+3.4.1: bugfix for import ctf, set missing defocus flag
 3.4.0:
   - move plugin-specific import CTF protocol to the core
   - add IMOD 4.11.25 version

--- a/imod/__init__.py
+++ b/imod/__init__.py
@@ -35,7 +35,7 @@ import pwem
 
 from .constants import IMOD_HOME, ETOMO_CMD, DEFAULT_VERSION, VERSIONS, IMOD_VIEWER_BINNING
 
-__version__ = '3.4.0'
+__version__ = '3.4.1'
 _logo = "icon.png"
 _references = ['Kremer1996', 'Mastronarde2017']
 

--- a/imod/protocols/protocol_base.py
+++ b/imod/protocols/protocol_base.py
@@ -545,6 +545,7 @@ class ProtImodBase(ProtTomoImportFiles, EMProtocol, ProtTomoBase):
             newCTFTomo.completeInfoFromList()
             newCTFTomoSeries.append(newCTFTomo)
 
+        newCTFTomoSeries.setIMODDefocusFileFlag(defocusFileFlag)
         newCTFTomoSeries.setNumberOfEstimationsInRangeFromDefocusList()
         newCTFTomoSeries.calculateDefocusUDeviation(defocusUTolerance=20)
         newCTFTomoSeries.calculateDefocusVDeviation(defocusVTolerance=20)


### PR DESCRIPTION
After the recent refactoring of CTF import, the flag was not set in the output