### PR TITLE
  - Prevent viewers from locking the screen focus.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,9 +1,10 @@
-3.4.1: bugfix for import ctf, set missing defocus flag
-3.4.0:
+3.3.0:
+  - bugfix for import ctf, set missing defocus flag
   - move plugin-specific import CTF protocol to the core
   - add IMOD 4.11.25 version
-3.3.0:
   - Prevent viewers from locking the screen focus.
+  - tilt series normalization: defines possible outputs
+  - tomo preprocess: always outputs mrc file
 3.2.4: bug fixed in odd-even management in CTF correction
 3.2.3: declare requirements.txt in manifest
 3.2.2:

--- a/imod/protocols/protocol_tsNormalization.py
+++ b/imod/protocols/protocol_tsNormalization.py
@@ -32,7 +32,7 @@ from pwem.emlib.image import ImageHandler
 import tomo.objects as tomoObj
 
 from .. import Plugin
-from .protocol_base import ProtImodBase, EXT_MRCS_TS_EVEN_NAME, EXT_MRCS_TS_ODD_NAME
+from .protocol_base import ProtImodBase, EXT_MRCS_TS_EVEN_NAME, EXT_MRCS_TS_ODD_NAME, OUTPUT_TILTSERIES_NAME
 from ..utils import formatTransformFile
 
 
@@ -45,6 +45,7 @@ class ProtImodTSNormalization(ProtImodBase):
 
     _label = 'Tilt-series preprocess'
     _devStatus = BETA
+    _possibleOutputs = {OUTPUT_TILTSERIES_NAME:tomoObj.SetOfTiltSeries}
 
     # -------------------------- DEFINE param functions -----------------------
     def _defineParams(self, form):


### PR DESCRIPTION
  - tilt series normalization: defines possible outputs
  - tomo preprocess: always outputs mrc file

  CHANGES corrected