### PR TITLE
fix fiducial alignment: output LM generation

### DIFF
--- a/imod/protocols/protocol_fiducialAlignment.py
+++ b/imod/protocols/protocol_fiducialAlignment.py
@@ -689,10 +689,12 @@ class ProtImodFiducialAlignment(ProtImodBase):
             prevTiltIm = 0
             chainId = 0
             indexFake = 0
+            firstExec = True
 
             for fiducial in fiducialNoGapList:
-                if int(float(fiducial[2])) <= prevTiltIm:
+                if (int(float(fiducial[2])) <= prevTiltIm) or firstExec:
                     chainId += 1
+                    firstExec = False
                 prevTiltIm = int(float(fiducial[2]))
 
                 if indexFake < len(fiducialNoGapsResidList) and fiducial[2] == fiducialNoGapsResidList[indexFake][2]:


### PR DESCRIPTION
Small fix in fiducial alignment. There is an error in the chin ID when generating the output LM model