### PR TITLE
Jj add acq order 2 ctftomo

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+3.4.2:
+ Developers:
+  - Update the acquisition order in the CTFTomo objects (field added to that class in scipion-em-tomo v3.7.0).
 3.3.0:
   - bugfix for import ctf, set missing defocus flag
   - move plugin-specific import CTF protocol to the core

--- a/imod/__init__.py
+++ b/imod/__init__.py
@@ -35,7 +35,7 @@ import pwem
 
 from .constants import IMOD_HOME, ETOMO_CMD, DEFAULT_VERSION, VERSIONS, IMOD_VIEWER_BINNING
 
-__version__ = '3.4.1'
+__version__ = '3.4.2'
 _logo = "icon.png"
 _references = ['Kremer1996', 'Mastronarde2017']
 

--- a/imod/protocols/protocol_base.py
+++ b/imod/protocols/protocol_base.py
@@ -493,7 +493,7 @@ class ProtImodBase(ProtTomoImportFiles, EMProtocol, ProtTomoBase):
         for ti in inputTs:
             tiObjId = ti.getObjId()
             newCTFTomo = CTFTomo()
-            newCTFTomo.setAcquisitionOrder(ti.getAcquisitonOrder())
+            newCTFTomo.setAcquisitionOrder(ti.getAcquisitionOrder())
 
             if tiObjId not in defocusUDict.keys() and not ti.isEnabled():
                 raise IndexError("ERROR IN TILT-SERIES %s: NO CTF ESTIMATED FOR VIEW %d, TILT ANGLE %f" % (

--- a/imod/protocols/protocol_base.py
+++ b/imod/protocols/protocol_base.py
@@ -490,57 +490,56 @@ class ProtImodBase(ProtTomoImportFiles, EMProtocol, ProtTomoBase):
                 f"Defocus file flag {defocusFileFlag} is not supported. Only supported formats "
                 "correspond to flags 0, 1, 4, 5, and 37.")
 
-        excludedViews = inputTs.getExcludedViewsIndex()
-        ids = inputTs.getIdSet()
-        for index in ids:
+        for ti in inputTs:
+            tiObjId = ti.getObjId()
             newCTFTomo = CTFTomo()
-            newCTFTomo.setIndex(index)
+            newCTFTomo.setAcquisitionOrder(ti.getAcquisitonOrder())
 
-            if index not in defocusUDict.keys() and index not in excludedViews:
+            if tiObjId not in defocusUDict.keys() and not ti.isEnabled():
                 raise IndexError("ERROR IN TILT-SERIES %s: NO CTF ESTIMATED FOR VIEW %d, TILT ANGLE %f" % (
-                    inputTs.getTsId(), index, inputTs[index].getTiltAngle()))
+                    inputTs.getTsId(), tiObjId, inputTs[tiObjId].getTiltAngle()))
 
             " Plain estimation (any defocus flag)"
             newCTFTomo._defocusUList = CsvList(pType=float)
-            newCTFTomo.setDefocusUList(defocusUDict.get(index, [0.]))
+            newCTFTomo.setDefocusUList(defocusUDict.get(tiObjId, [0.]))
 
             if defocusFileFlag == 1:
                 " Astigmatism estimation "
                 newCTFTomo._defocusVList = CsvList(pType=float)
-                newCTFTomo.setDefocusVList(defocusVDict.get(index, [0.]))
+                newCTFTomo.setDefocusVList(defocusVDict.get(tiObjId, [0.]))
 
                 newCTFTomo._defocusAngleList = CsvList(pType=float)
-                newCTFTomo.setDefocusAngleList(defocusAngleDict.get(index, [0.]))
+                newCTFTomo.setDefocusAngleList(defocusAngleDict.get(tiObjId, [0.]))
 
             elif defocusFileFlag == 4:
                 " Phase-shift information "
                 newCTFTomo._phaseShiftList = CsvList(pType=float)
-                newCTFTomo.setPhaseShiftList(phaseShiftDict.get(index, [0.]))
+                newCTFTomo.setPhaseShiftList(phaseShiftDict.get(tiObjId, [0.]))
 
             elif defocusFileFlag == 5:
                 " Astigmatism and phase shift estimation "
                 newCTFTomo._defocusVList = CsvList(pType=float)
-                newCTFTomo.setDefocusVList(defocusVDict.get(index, [0.]))
+                newCTFTomo.setDefocusVList(defocusVDict.get(tiObjId, [0.]))
 
                 newCTFTomo._defocusAngleList = CsvList(pType=float)
-                newCTFTomo.setDefocusAngleList(defocusAngleDict.get(index, [0.]))
+                newCTFTomo.setDefocusAngleList(defocusAngleDict.get(tiObjId, [0.]))
 
                 newCTFTomo._phaseShiftList = CsvList(pType=float)
-                newCTFTomo.setPhaseShiftList(phaseShiftDict.get(index, [0.]))
+                newCTFTomo.setPhaseShiftList(phaseShiftDict.get(tiObjId, [0.]))
 
             elif defocusFileFlag == 37:
                 " Astigmatism, phase shift and cut-on frequency estimation "
                 newCTFTomo._defocusVList = CsvList(pType=float)
-                newCTFTomo.setDefocusVList(defocusVDict.get(index, [0.]))
+                newCTFTomo.setDefocusVList(defocusVDict.get(tiObjId, [0.]))
 
                 newCTFTomo._defocusAngleList = CsvList(pType=float)
-                newCTFTomo.setDefocusAngleList(defocusAngleDict.get(index, [0.]))
+                newCTFTomo.setDefocusAngleList(defocusAngleDict.get(tiObjId, [0.]))
 
                 newCTFTomo._phaseShiftList = CsvList(pType=float)
-                newCTFTomo.setPhaseShiftList(phaseShiftDict.get(index, [0.]))
+                newCTFTomo.setPhaseShiftList(phaseShiftDict.get(tiObjId, [0.]))
 
                 newCTFTomo._cutOnFreqList = CsvList(pType=float)
-                newCTFTomo.setCutOnFreqList(cutOnFreqDict.get(index, [0.]))
+                newCTFTomo.setCutOnFreqList(cutOnFreqDict.get(tiObjId, [0.]))
 
             newCTFTomo.completeInfoFromList()
             newCTFTomoSeries.append(newCTFTomo)

--- a/imod/protocols/protocol_base.py
+++ b/imod/protocols/protocol_base.py
@@ -494,6 +494,7 @@ class ProtImodBase(ProtTomoImportFiles, EMProtocol, ProtTomoBase):
             tiObjId = ti.getObjId()
             newCTFTomo = CTFTomo()
             newCTFTomo.setAcquisitionOrder(ti.getAcquisitionOrder())
+            newCTFTomo.setIndex(ti.getIndex())
 
             if tiObjId not in defocusUDict.keys() and not ti.isEnabled():
                 raise IndexError("ERROR IN TILT-SERIES %s: NO CTF ESTIMATED FOR VIEW %d, TILT ANGLE %f" % (

--- a/imod/utils.py
+++ b/imod/utils.py
@@ -827,7 +827,7 @@ def generateDefocusIMODFileFromObject(ctfTomoSeries, defocusFilePath,
             # upside down Scipion (highest index for
             # the tilt-image with the highest negative angle)
             for ctfTomo in ctfTomoSeries:
-                index = ctfTomo.getIndex().get()
+                index = ctfTomo.getIndex()
 
                 newLine = ("%d\t%d\t%.2f\t%.2f\t%.1f\t%.1f\t%.2f\n" % (
                     index,
@@ -857,7 +857,7 @@ def generateDefocusUDictionary(ctfTomoSeries):
             else ctfTomo.getDefocusVList()
         defocusInfoList = defocusInfoList.split(",")
 
-        index = ctfTomo.getIndex().get()
+        index = ctfTomo.getIndex()
 
         defocusUDict[index] = defocusInfoList
 
@@ -875,7 +875,7 @@ def generateDefocusVDictionary(ctfTomoSeries):
         defocusInfoList = ctfTomo.getDefocusVList()
         defocusInfoList = defocusInfoList.split(",")
 
-        index = ctfTomo.getIndex().get()
+        index = ctfTomo.getIndex()
 
         defocusVDict[index] = defocusInfoList
 
@@ -893,7 +893,7 @@ def generateDefocusAngleDictionary(ctfTomoSeries):
         defocusAngleList = ctfTomo.getDefocusAngleList()
         defocusAngleList = defocusAngleList.split(",")
 
-        index = ctfTomo.getIndex().get()
+        index = ctfTomo.getIndex()
 
         defocusAngleDict[index] = defocusAngleList
 
@@ -911,7 +911,7 @@ def generatePhaseShiftDictionary(ctfTomoSeries):
         phaseShiftList = ctfTomo.getPhaseShiftList()
         phaseShiftList = phaseShiftList.split(",")
 
-        index = ctfTomo.getIndex().get()
+        index = ctfTomo.getIndex()
 
         phaseShiftDict[index] = phaseShiftList
 
@@ -929,7 +929,7 @@ def generateCutOnFreqDictionary(ctfTomoSeries):
         cutOnFreqList = ctfTomo.getCutOnFreqList()
         cutOnFreqList = cutOnFreqList.split(",")
 
-        index = ctfTomo.getIndex().get()
+        index = ctfTomo.getIndex()
 
         cutOnFreqDict[index] = cutOnFreqList
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-scipion-em-tomo
+scipion-em-tomo>=3.7.0


### PR DESCRIPTION
In scipion-em-tomo version 3.7.0, the acquisition order has been added to the CTFTomo to provide a robust field to match between tilt-images and CTFTomo when they come from different places, such as in Reliontomo prepare or IMOD ctf correction. It opens a way to robustly deal with re-stacked files, excluded vies, etc.