### PR TITLE
Fixed extensions in protocol_tomoReconstruction.py, only uses MRC_EXT now

### DIFF
--- a/imod/protocols/protocol_applyTransformationMatrix.py
+++ b/imod/protocols/protocol_applyTransformationMatrix.py
@@ -165,10 +165,10 @@ class ProtImodApplyTransformationMatrix(ProtImodBase):
             oddFn = firstItem.getOdd().split('@')[1]
             evenFn = firstItem.getEven().split('@')[1]
             paramsAlignment['input'] = oddFn
-            paramsAlignment['output'] = self.getExtraOutFile(tsId, suffix=ODD, ext=MRCS_EXT)
+            paramsAlignment['output'] = self.getExtraOutFile(tsId, suffix=ODD)
             Plugin.runImod(self, 'newstack', argsAlignment % paramsAlignment)
             paramsAlignment['input'] = evenFn
-            paramsAlignment['output'] = self.getExtraOutFile(tsId, suffix=EVEN, ext=MRCS_EXT)
+            paramsAlignment['output'] = self.getExtraOutFile(tsId, suffix=EVEN)
             Plugin.runImod(self, 'newstack', argsAlignment % paramsAlignment)
 
     def generateOutputStackStep(self, tsId):
@@ -203,8 +203,8 @@ class ProtImodApplyTransformationMatrix(ProtImodBase):
                     newTi.setAcquisition(acq)
                     newTi.setLocation(index, outputLocation)
                     if self.applyToOddEven(ts):
-                        locationOdd = index, (self.getExtraOutFile(tsId, suffix=ODD, ext=MRCS_EXT))
-                        locationEven = index, (self.getExtraOutFile(tsId, suffix=EVEN, ext=MRCS_EXT))
+                        locationOdd = index, (self.getExtraOutFile(tsId, suffix=ODD))
+                        locationEven = index, (self.getExtraOutFile(tsId, suffix=EVEN))
                         newTi.setOddEven([ih.locationToXmipp(locationOdd), ih.locationToXmipp(locationEven)])
                     else:
                         newTi.setOddEven([])

--- a/imod/protocols/protocol_applyTransformationMatrix.py
+++ b/imod/protocols/protocol_applyTransformationMatrix.py
@@ -31,7 +31,7 @@ from pyworkflow.object import Set
 from pwem.emlib.image import ImageHandler
 from tomo.objects import TiltSeries, TiltImage
 from .. import Plugin, utils
-from .protocol_base import ProtImodBase,XF_EXT, ODD, EVEN, MRCS_EXT
+from .protocol_base import ProtImodBase, XF_EXT, ODD, EVEN
 
 
 class ProtImodApplyTransformationMatrix(ProtImodBase):

--- a/imod/protocols/protocol_base.py
+++ b/imod/protocols/protocol_base.py
@@ -24,7 +24,6 @@
 # *
 # *****************************************************************************
 import logging
-import os
 
 from pyworkflow.object import Set, CsvList, Pointer
 from pyworkflow.protocol import STEPS_PARALLEL, params
@@ -451,7 +450,7 @@ class ProtImodBase(ProtTomoImportFiles, EMProtocol, ProtTomoBase):
 
             if binning > 1:
                 samplingRate = inputSet.getSamplingRate()
-                samplingRate *= self.binning.get()
+                samplingRate *= self.binning
                 outputSetOfTiltSeries.setSamplingRate(samplingRate)
 
             outputSetOfTiltSeries.setStreamState(Set.STREAM_OPEN)
@@ -481,7 +480,7 @@ class ProtImodBase(ProtTomoImportFiles, EMProtocol, ProtTomoBase):
 
             if self.binning > 1:
                 samplingRate = inputSet.getSamplingRate()
-                samplingRate *= self.binning.get()
+                samplingRate *= self.binning
                 outputInterpolatedSetOfTiltSeries.setSamplingRate(samplingRate)
 
             outputInterpolatedSetOfTiltSeries.setStreamState(Set.STREAM_OPEN)
@@ -598,8 +597,6 @@ class ProtImodBase(ProtTomoImportFiles, EMProtocol, ProtTomoBase):
 
         if self.Tomograms:
             getattr(self, OUTPUT_TOMOGRAMS_NAME).enableAppend()
-
-
         else:
             outputSetOfTomograms = self._createSetOfTomograms()
 
@@ -612,7 +609,7 @@ class ProtImodBase(ProtTomoImportFiles, EMProtocol, ProtTomoBase):
 
             if binning > 1:
                 samplingRate = inputSet.getSamplingRate()
-                samplingRate *= self.binning.get()
+                samplingRate *= self.binning
                 outputSetOfTomograms.setSamplingRate(samplingRate)
 
             outputSetOfTomograms.setStreamState(Set.STREAM_OPEN)
@@ -759,7 +756,7 @@ class ProtImodBase(ProtTomoImportFiles, EMProtocol, ProtTomoBase):
                 newTi.setAcquisition(tiltImage.getAcquisition())
                 newTi.setLocation(tiltImage.getLocation())
                 if hasattr(self, "binning") and self.binning > 1:
-                    newTi.setSamplingRate(tiltImage.getSamplingRate() * self.binning.get())
+                    newTi.setSamplingRate(tiltImage.getSamplingRate() * self.binning)
                 newTs.append(newTi)
 
             ih = ImageHandler()

--- a/imod/protocols/protocol_base.py
+++ b/imod/protocols/protocol_base.py
@@ -450,7 +450,7 @@ class ProtImodBase(ProtTomoImportFiles, EMProtocol, ProtTomoBase):
 
             if binning > 1:
                 samplingRate = inputSet.getSamplingRate()
-                samplingRate *= self.binning
+                samplingRate *= self.binning.get()
                 outputSetOfTiltSeries.setSamplingRate(samplingRate)
 
             outputSetOfTiltSeries.setStreamState(Set.STREAM_OPEN)
@@ -480,7 +480,7 @@ class ProtImodBase(ProtTomoImportFiles, EMProtocol, ProtTomoBase):
 
             if self.binning > 1:
                 samplingRate = inputSet.getSamplingRate()
-                samplingRate *= self.binning
+                samplingRate *= self.binning.get()
                 outputInterpolatedSetOfTiltSeries.setSamplingRate(samplingRate)
 
             outputInterpolatedSetOfTiltSeries.setStreamState(Set.STREAM_OPEN)
@@ -609,7 +609,7 @@ class ProtImodBase(ProtTomoImportFiles, EMProtocol, ProtTomoBase):
 
             if binning > 1:
                 samplingRate = inputSet.getSamplingRate()
-                samplingRate *= self.binning
+                samplingRate *= self.binning.get()
                 outputSetOfTomograms.setSamplingRate(samplingRate)
 
             outputSetOfTomograms.setStreamState(Set.STREAM_OPEN)

--- a/imod/protocols/protocol_base.py
+++ b/imod/protocols/protocol_base.py
@@ -244,24 +244,18 @@ class ProtImodBase(ProtTomoImportFiles, EMProtocol, ProtTomoBase):
 
         return wrapper
 
-    def getTmpTSFile(self, tsId, tmpPrefix=None, suffix=".mrcs"):
-        if tmpPrefix is None:
-            tmpPrefix = self._getTmpPath(tsId)
-
-        return os.path.join(tmpPrefix, tsId + suffix)
-
     def genTsPaths(self, tsId):
         """Generate the subdirectories corresponding to the current tilt-series in tmp and extra"""
         path.makePath(*[self._getExtraPath(tsId), self._getTmpPath(tsId)])
 
     @staticmethod
-    def getOutTsFileName(tsId, suffix=None, ext='mrc'):
+    def getOutTsFileName(tsId, suffix=None, ext=MRCS_EXT):
         return f'{tsId}_{suffix}.{ext}' if suffix else f'{tsId}.{ext}'
 
-    def getTmpOutFile(self, tsId, suffix=None, ext='mrc'):
+    def getTmpOutFile(self, tsId, suffix=None, ext=MRCS_EXT):
         return self._getTmpPath(tsId, self.getOutTsFileName(tsId, suffix=suffix, ext=ext))
 
-    def getExtraOutFile(self, tsId, suffix=None, ext='mrc'):
+    def getExtraOutFile(self, tsId, suffix=None, ext=MRCS_EXT):
         return self._getExtraPath(tsId, self.getOutTsFileName(tsId, suffix=suffix, ext=ext))
 
     def convertInputStep(self, tsObjId, generateAngleFile=True, imodInterpolation=True, doSwap=False,
@@ -322,8 +316,8 @@ class ProtImodBase(ProtTomoImportFiles, EMProtocol, ProtTomoBase):
         if oddEven:
             fnOdd = ts.getOddFileName()
             fnEven = ts.getEvenFileName()
-            outputOddTsFileName = self.getTmpOutFile(tsId, suffix=ODD, ext=MRCS_EXT)
-            outputEvenTsFileName = self.getTmpOutFile(tsId, suffix=EVEN, ext=MRCS_EXT)
+            outputOddTsFileName = self.getTmpOutFile(tsId, suffix=ODD)
+            outputEvenTsFileName = self.getTmpOutFile(tsId, suffix=EVEN)
 
         # Interpolation
         if imodInterpolation is None:

--- a/imod/protocols/protocol_base.py
+++ b/imod/protocols/protocol_base.py
@@ -756,7 +756,7 @@ class ProtImodBase(ProtTomoImportFiles, EMProtocol, ProtTomoBase):
                 newTi.setAcquisition(tiltImage.getAcquisition())
                 newTi.setLocation(tiltImage.getLocation())
                 if hasattr(self, "binning") and self.binning > 1:
-                    newTi.setSamplingRate(tiltImage.getSamplingRate() * self.binning)
+                    newTi.setSamplingRate(tiltImage.getSamplingRate() * self.binning.get())
                 newTs.append(newTi)
 
             ih = ImageHandler()

--- a/imod/protocols/protocol_ctfCorrection.py
+++ b/imod/protocols/protocol_ctfCorrection.py
@@ -238,13 +238,13 @@ class ProtImodCtfCorrection(ProtImodBase):
 
         if self.applyToOddEven(ts):
             # ODD
-            paramsCtfPhaseFlip['inputStack'] = self.getTmpOutFile(tsId, suffix=ODD, ext=MRCS_EXT)
-            paramsCtfPhaseFlip['outputFileName'] = self.getExtraOutFile(tsId, suffix=ODD, ext=MRCS_EXT)
+            paramsCtfPhaseFlip['inputStack'] = self.getTmpOutFile(tsId, suffix=ODD)
+            paramsCtfPhaseFlip['outputFileName'] = self.getExtraOutFile(tsId, suffix=ODD)
             Plugin.runImod(self, 'ctfphaseflip', argsCtfPhaseFlip % paramsCtfPhaseFlip)
 
             # EVEN
-            paramsCtfPhaseFlip['inputStack'] = self.getTmpOutFile(tsId, suffix=EVEN, ext=MRCS_EXT)
-            paramsCtfPhaseFlip['outputFileName'] = self.getExtraOutFile(tsId, suffix=EVEN, ext=MRCS_EXT)
+            paramsCtfPhaseFlip['inputStack'] = self.getTmpOutFile(tsId, suffix=EVEN)
+            paramsCtfPhaseFlip['outputFileName'] = self.getExtraOutFile(tsId, suffix=EVEN)
             Plugin.runImod(self, 'ctfphaseflip', argsCtfPhaseFlip % paramsCtfPhaseFlip)
 
     def createOutputStep(self, tsId, presentAcqOrders):
@@ -274,8 +274,8 @@ class ProtImodCtfCorrection(ProtImodBase):
                     newTi.setAcquisition(acq)
                     newTi.setLocation(index + 1, self.getExtraOutFile(tsId))
                     if self.applyToOddEven(ts):
-                        locationOdd = index + 1, self.getExtraOutFile(tsId, suffix=ODD, ext=MRCS_EXT)
-                        locationEven = index + 1, self.getExtraOutFile(tsId, suffix=EVEN, ext=MRCS_EXT)
+                        locationOdd = index + 1, self.getExtraOutFile(tsId, suffix=ODD)
+                        locationEven = index + 1, self.getExtraOutFile(tsId, suffix=EVEN)
                         newTi.setOddEven([ih.locationToXmipp(locationOdd), ih.locationToXmipp(locationEven)])
                     else:
                         newTi.setOddEven([])

--- a/imod/protocols/protocol_ctfCorrection.py
+++ b/imod/protocols/protocol_ctfCorrection.py
@@ -31,7 +31,7 @@ from pwem.emlib.image import ImageHandler
 from tomo.objects import TiltSeries, TiltImage
 from tomo.utils import getCommonTsAndCtfElements
 from .. import Plugin, utils
-from .protocol_base import ProtImodBase, DEFOCUS_EXT, TLT_EXT, XF_EXT, ODD, MRCS_EXT, EVEN
+from .protocol_base import ProtImodBase, DEFOCUS_EXT, TLT_EXT, XF_EXT, ODD, EVEN
 
 
 class ProtImodCtfCorrection(ProtImodBase):
@@ -251,7 +251,6 @@ class ProtImodCtfCorrection(ProtImodBase):
         if tsId not in self._failedTs:
             inTsSet = self.inputSetOfTiltSeries.get()
             outputSetOfTs = self.getOutputSetOfTiltSeries(inTsSet)
-            extraPrefix = self._getExtraPath(tsId)
 
             newTs = TiltSeries(tsId=tsId)
             ts = self.tsDict[tsId]

--- a/imod/protocols/protocol_doseFilter.py
+++ b/imod/protocols/protocol_doseFilter.py
@@ -165,12 +165,12 @@ class ProtImodDoseFilter(ProtImodBase):
         if self.applyToOddEven(ts):
             oddFn = firstItem.getOdd().split('@')[1]
             paramsMtffilter['input'] = oddFn
-            paramsMtffilter['output'] = self.getExtraOutFile(tsId, suffix=ODD, ext=MRCS_EXT)
+            paramsMtffilter['output'] = self.getExtraOutFile(tsId, suffix=ODD)
 
             Plugin.runImod(self, 'mtffilter', argsMtffilter % paramsMtffilter)
             evenFn = firstItem.getEven().split('@')[1]
             paramsMtffilter['input'] = evenFn
-            paramsMtffilter['output'] = self.getExtraOutFile(tsId, suffix=EVEN, ext=MRCS_EXT)
+            paramsMtffilter['output'] = self.getExtraOutFile(tsId, suffix=EVEN)
             Plugin.runImod(self, 'mtffilter', argsMtffilter % paramsMtffilter)
 
     def createOutputStep(self, tsId):
@@ -188,8 +188,8 @@ class ProtImodDoseFilter(ProtImodBase):
             newTi.copyInfo(tiltImage, copyId=True, copyTM=True)
             newTi.setAcquisition(tiltImage.getAcquisition())
             if self.applyToOddEven(ts):
-                locationOdd = index + 1, self.getExtraOutFile(tsId, suffix=ODD, ext=MRCS_EXT)
-                locationEven = index + 1, self.getExtraOutFile(tsId, suffix=EVEN, ext=MRCS_EXT)
+                locationOdd = index + 1, self.getExtraOutFile(tsId, suffix=ODD)
+                locationEven = index + 1, self.getExtraOutFile(tsId, suffix=EVEN)
                 newTi.setOddEven([ih.locationToXmipp(locationOdd), ih.locationToXmipp(locationEven)])
             else:
                 newTi.setOddEven([])

--- a/imod/protocols/protocol_doseFilter.py
+++ b/imod/protocols/protocol_doseFilter.py
@@ -30,7 +30,7 @@ import tomo.objects as tomoObj
 from pwem.emlib.image import ImageHandler
 
 from .. import Plugin, utils
-from .protocol_base import ProtImodBase, ODD, MRCS_EXT, EVEN
+from .protocol_base import ProtImodBase, ODD, EVEN
 
 SCIPION_IMPORT = 0
 FIXED_DOSE = 1

--- a/imod/protocols/protocol_fiducialAlignment.py
+++ b/imod/protocols/protocol_fiducialAlignment.py
@@ -200,11 +200,11 @@ class ProtImodFiducialAlignment(ProtImodBase):
                       label='Rotation solution type',
                       display=params.EnumParam.DISPLAY_HLIST,
                       help='Type of rotation solution: See rotOption in tiltalign IMOD command \n'
-                        '* No rotation: The in-plane rotation will not be estimated\n'
-                        '* One rotation: To solve for a single rotation variable \n'
-                        '* Group rotations: Group views to solve for fewer rotations variables. Automapping of '
+                           '* No rotation: The in-plane rotation will not be estimated\n'
+                           '* One rotation: To solve for a single rotation variable \n'
+                           '* Group rotations: Group views to solve for fewer rotations variables. Automapping of '
                            'rotation variables linearly changing values\n'
-                        '* Solve for all rotations: for each view having an independent rotation\n')
+                           '* Solve for all rotations: for each view having an independent rotation\n')
 
         form.addParam('groupRotationSize',
                       params.IntParam,

--- a/imod/protocols/protocol_fiducialModel.py
+++ b/imod/protocols/protocol_fiducialModel.py
@@ -370,8 +370,6 @@ class ProtImodFiducialModel(ProtImodBase):
             Plugin.runImod(self, 'beadtrack', argsBeadtrack % paramsBeadtrack)
 
     def translateFiducialPointModelStep(self, tsId):
-        ts = self.tsDict[tsId]
-
         # Check that previous steps have been completed satisfactorily
         gapsFidFile = self.getExtraOutFile(tsId, suffix='gaps', ext=FID_EXT)
         if os.path.exists(gapsFidFile):
@@ -540,7 +538,6 @@ class ProtImodFiducialModel(ProtImodBase):
     def translateTrackCom(self, ts, paramsDict):
         tsId = ts.getTsId()
         extraPrefix = self._getExtraPath(tsId)
-        tmpPrefix = self._getTmpPath(tsId)
 
         firstItem = ts.getFirstItem()
         trackFilePath = os.path.join(extraPrefix,

--- a/imod/protocols/protocol_goldBeadPicker3d.py
+++ b/imod/protocols/protocol_goldBeadPicker3d.py
@@ -24,11 +24,8 @@
 # *
 # *****************************************************************************
 
-import os
-
 from pyworkflow import BETA
 import pyworkflow.protocol.params as params
-from pyworkflow.utils import path, removeBaseExt
 from pyworkflow.object import Set
 import tomo.objects as tomoObj
 import tomo.constants as constants

--- a/imod/protocols/protocol_tomoPreprocess.py
+++ b/imod/protocols/protocol_tomoPreprocess.py
@@ -300,7 +300,7 @@ class ProtImodTomoNormalization(ProtImodBase):
 
         if binning != 1:
             if runNewstack:
-                tmpPath = self.getTmpOutFile(tsId, ext=MRC_EXT)
+                tmpPath = self.getTmpOutFile(tsId)
                 pwpath.moveFile(outputFile, tmpPath)
                 inputTomoPath = tmpPath
 
@@ -308,8 +308,8 @@ class ProtImodTomoNormalization(ProtImodBase):
                     pwpath.moveFile(oddEvenOutput[0], tmpPath)
                     pwpath.moveFile(oddEvenOutput[1], tmpPath)
                     inputTomoPath = tmpPath
-                    inputOdd, inputEven = (self.getTmpOutFile(tsId, suffix=ODD, ext=MRC_EXT),
-                                           self.getTmpOutFile(tsId, suffix=EVEN, ext=MRC_EXT))
+                    inputOdd, inputEven = (self.getTmpOutFile(tsId, suffix=ODD),
+                                           self.getTmpOutFile(tsId, suffix=EVEN))
             else:
                 inputTomoPath = location
                 if self.applyToOddEven(tomo):

--- a/imod/protocols/protocol_tomoPreprocess.py
+++ b/imod/protocols/protocol_tomoPreprocess.py
@@ -29,7 +29,7 @@ import pyworkflow.protocol.params as params
 import pyworkflow.utils.path as pwpath
 from tomo.objects import Tomogram, SetOfTomograms
 from .. import Plugin
-from .protocol_base import ProtImodBase,OUTPUT_TOMOGRAMS_NAME, MRC_EXT, ODD, EVEN
+from .protocol_base import ProtImodBase, OUTPUT_TOMOGRAMS_NAME, MRC_EXT, ODD, EVEN
 
 
 class ProtImodTomoNormalization(ProtImodBase):

--- a/imod/protocols/protocol_tomoProjection.py
+++ b/imod/protocols/protocol_tomoProjection.py
@@ -24,18 +24,15 @@
 # *
 # *****************************************************************************
 
-import os
-
 from pwem.objects import Transform
 from pyworkflow import BETA
 from pyworkflow.object import Set
 import pyworkflow.protocol.params as params
-import pyworkflow.utils.path as path
 from pwem.emlib.image import ImageHandler
 import tomo.objects as tomoObj
 
 from .. import Plugin
-from .protocol_base import ProtImodBase, MRC_EXT
+from .protocol_base import ProtImodBase, MRCS_EXT
 
 
 class ProtImodTomoProjection(ProtImodBase):
@@ -116,7 +113,7 @@ class ProtImodTomoProjection(ProtImodBase):
 
         paramsXYZproj = {
             'input': tomo.getFileName(),
-            'output': self.getExtraOutFile(tsId, ext=MRC_EXT),
+            'output': self.getExtraOutFile(tsId, ext=MRCS_EXT),
             'axis': self.getRotationAxis(),
             'angles': str(self.minAngle.get()) + ',' +
                       str(self.maxAngle.get()) + ',' +
@@ -147,7 +144,7 @@ class ProtImodTomoProjection(ProtImodBase):
             newTi.setTsId(tsId)
             newTi.setAcquisitionOrder(index + 1)
             newTi.setLocation(index + 1,
-                              self.getExtraOutFile(tsId, ext=MRC_EXT))
+                              self.getExtraOutFile(tsId, ext=MRCS_EXT))
             newTi.setSamplingRate(sRate)
             newTs.append(newTi)
 

--- a/imod/protocols/protocol_tomoReconstruction.py
+++ b/imod/protocols/protocol_tomoReconstruction.py
@@ -32,8 +32,7 @@ import pyworkflow.protocol.params as params
 from tomo.objects import Tomogram
 
 from .. import Plugin
-from .protocol_base import (ProtImodBase, EXT_MRC_ODD_NAME, EXT_MRC_EVEN_NAME,
-                            EXT_MRCS_TS_EVEN_NAME, EXT_MRCS_TS_ODD_NAME, TLT_EXT, ODD, MRCS_EXT, EVEN, MRC_EXT, REC_EXT)
+from .protocol_base import ProtImodBase, TLT_EXT, ODD, EVEN, MRC_EXT
 
 
 class ProtImodTomoReconstruction(ProtImodBase):
@@ -312,12 +311,12 @@ class ProtImodTomoReconstruction(ProtImodBase):
         oddEvenTmp = [[], []]
 
         if self.applyToOddEven(ts):
-            paramsTilt['InputProjections'] = self.getTmpOutFile(tsId, suffix=ODD, ext=MRCS_EXT)
+            paramsTilt['InputProjections'] = self.getTmpOutFile(tsId, suffix=ODD)
             oddEvenTmp[0] = self.getExtraOutFile(tsId, suffix=ODD, ext=MRC_EXT)
             paramsTilt['OutputFile'] = oddEvenTmp[0]
             Plugin.runImod(self, 'tilt', argsTilt % paramsTilt)
 
-            paramsTilt['InputProjections'] = self.getTmpOutFile(tsId, suffix=EVEN, ext=MRCS_EXT)
+            paramsTilt['InputProjections'] = self.getTmpOutFile(tsId, suffix=EVEN)
             oddEvenTmp[1] = self.getExtraOutFile(tsId, suffix=EVEN, ext=MRC_EXT)
             paramsTilt['OutputFile'] = oddEvenTmp[1]
             Plugin.runImod(self, 'tilt', argsTilt % paramsTilt)

--- a/imod/protocols/protocol_tomoReconstruction.py
+++ b/imod/protocols/protocol_tomoReconstruction.py
@@ -88,25 +88,25 @@ class ProtImodTomoReconstruction(ProtImodBase):
                       help='Number of pixels to cut out in X, centered on the middle in X. Leave 0 for default X.')
 
         lineShift = form.addLine('Tomogram shift (Å)',
-                             expertLevel=params.LEVEL_ADVANCED,
-                             help="This entry allows one to shift the reconstructed"
-                                  " slice in X or Z before it is output.  If the "
-                                  " X shift is positive, the slice will be shifted to "
-                                  " the right, and the output will contain the left "
-                                  " part of the whole potentially reconstructable area. "
-                                  " If the Z shift is positive, the slice is shifted "
-                                  " upward. The Z entry is optional and defaults to 0 when "
-                                  " omitted.")
+                                 expertLevel=params.LEVEL_ADVANCED,
+                                 help="This entry allows one to shift the reconstructed"
+                                      " slice in X or Z before it is output.  If the "
+                                      " X shift is positive, the slice will be shifted to "
+                                      " the right, and the output will contain the left "
+                                      " part of the whole potentially reconstructable area. "
+                                      " If the Z shift is positive, the slice is shifted "
+                                      " upward. The Z entry is optional and defaults to 0 when "
+                                      " omitted.")
 
         lineShift.addParam('tomoShiftX',
-                      params.FloatParam,
-                      default=0,
-                      label=' in X ')
+                           params.FloatParam,
+                           default=0,
+                           label=' in X ')
 
         lineShift.addParam('tomoShiftZ',
-                      params.FloatParam,
-                      default=0,
-                      label=' in Z ')
+                           params.FloatParam,
+                           default=0,
+                           label=' in Z ')
 
         lineoffSet = form.addLine('Offset (deg) of the ',
                                   expertLevel=params.LEVEL_ADVANCED,
@@ -116,25 +116,22 @@ class ProtImodTomoReconstruction(ProtImodBase):
                                        "projection images, cutting the X-axis at NX/2 + offset instead of NX/2.")
 
         lineoffSet.addParam('angleOffset',
-                      params.FloatParam,
-                      default=0,
-                      label='Tilt angles ',
-                      help='Apply an angle offset in degrees to all tilt '
-                           'angles. This offset positively rotates the '
-                           'reconstructed sections anticlockwise.')
+                            params.FloatParam,
+                            default=0,
+                            label='Tilt angles ',
+                            help='Apply an angle offset in degrees to all tilt '
+                                 'angles. This offset positively rotates the '
+                                 'reconstructed sections anticlockwise.')
 
         lineoffSet.addParam('tiltAxisOffset',
-                      params.FloatParam,
-                      default=0,
-                      label='Tilt axis',
-                      help='Apply an offset to the tilt axis in a stack of '
-                           'full-sized projection images, cutting the '
-                           'X-axis at NX/2 + offset instead of NX/2. The '
-                           'DELXX entry is optional and defaults to 0 '
-                           'when omitted.')
-
-
-
+                            params.FloatParam,
+                            default=0,
+                            label='Tilt axis',
+                            help='Apply an offset to the tilt axis in a stack of '
+                                 'full-sized projection images, cutting the '
+                                 'X-axis at NX/2 + offset instead of NX/2. The '
+                                 'DELXX entry is optional and defaults to 0 '
+                                 'when omitted.')
 
         form.addParam('superSampleFactor',
                       params.IntParam,

--- a/imod/protocols/protocol_tomoReconstruction.py
+++ b/imod/protocols/protocol_tomoReconstruction.py
@@ -261,7 +261,7 @@ class ProtImodTomoReconstruction(ProtImodBase):
         ts = self.tsDict[tsId]
         paramsTilt = {
             'InputProjections': self.getTmpOutFile(tsId),
-            'OutputFile': self.getTmpOutFile(tsId, ext=REC_EXT),
+            'OutputFile': self.getTmpOutFile(tsId, ext=MRC_EXT),
             'TiltFile': self.getExtraOutFile(tsId, ext=TLT_EXT),
             'Thickness': self.tomoThickness.get(),
             'FalloffIsTrueSigma': 1,
@@ -313,17 +313,17 @@ class ProtImodTomoReconstruction(ProtImodBase):
 
         if self.applyToOddEven(ts):
             paramsTilt['InputProjections'] = self.getTmpOutFile(tsId, suffix=ODD, ext=MRCS_EXT)
-            oddEvenTmp[0] = self.getExtraOutFile(tsId, suffix=ODD, ext=REC_EXT)
+            oddEvenTmp[0] = self.getExtraOutFile(tsId, suffix=ODD, ext=MRC_EXT)
             paramsTilt['OutputFile'] = oddEvenTmp[0]
             Plugin.runImod(self, 'tilt', argsTilt % paramsTilt)
 
             paramsTilt['InputProjections'] = self.getTmpOutFile(tsId, suffix=EVEN, ext=MRCS_EXT)
-            oddEvenTmp[1] = self.getExtraOutFile(tsId, suffix=EVEN, ext=REC_EXT)
+            oddEvenTmp[1] = self.getExtraOutFile(tsId, suffix=EVEN, ext=MRC_EXT)
             paramsTilt['OutputFile'] = oddEvenTmp[1]
             Plugin.runImod(self, 'tilt', argsTilt % paramsTilt)
 
         paramsTrimVol = {
-            'input': self.getTmpOutFile(tsId, ext=REC_EXT),
+            'input': self.getTmpOutFile(tsId, ext=MRC_EXT),
             'output': self.getExtraOutFile(tsId, ext=MRC_EXT),
             'options': getArgs()
         }
@@ -336,11 +336,11 @@ class ProtImodTomoReconstruction(ProtImodBase):
 
         if self.applyToOddEven(ts):
             paramsTrimVol['input'] = oddEvenTmp[0]
-            paramsTrimVol['output'] = self.getExtraOutFile(tsId, suffix=ODD, ext=MRCS_EXT)
+            paramsTrimVol['output'] = self.getExtraOutFile(tsId, suffix=ODD, ext=MRC_EXT)
             Plugin.runImod(self, 'trimvol', argsTrimvol % paramsTrimVol)
 
             paramsTrimVol['input'] = oddEvenTmp[1]
-            paramsTrimVol['output'] = self.getExtraOutFile(tsId, suffix=EVEN, ext=MRCS_EXT)
+            paramsTrimVol['output'] = self.getExtraOutFile(tsId, suffix=EVEN, ext=MRC_EXT)
             Plugin.runImod(self, 'trimvol', argsTrimvol % paramsTrimVol)
 
     def createOutputStep(self, tsId):
@@ -354,8 +354,8 @@ class ProtImodTomoReconstruction(ProtImodBase):
             newTomogram.setLocation(tomoLocation)
 
             if self.applyToOddEven(ts):
-                halfMapsList = [self.getExtraOutFile(tsId, suffix=ODD, ext=MRCS_EXT),
-                                self.getExtraOutFile(tsId, suffix=EVEN, ext=MRCS_EXT)]
+                halfMapsList = [self.getExtraOutFile(tsId, suffix=ODD, ext=MRC_EXT),
+                                self.getExtraOutFile(tsId, suffix=EVEN, ext=MRC_EXT)]
                 newTomogram.setHalfMaps(halfMapsList)
 
             newTomogram.setTsId(tsId)

--- a/imod/protocols/protocol_tsPreprocess.py
+++ b/imod/protocols/protocol_tsPreprocess.py
@@ -309,10 +309,10 @@ class ProtImodTsNormalization(ProtImodBase):
             oddFn = firstItem.getOdd().split('@')[1]
             evenFn = firstItem.getEven().split('@')[1]
             paramsNewstack['input'] = oddFn
-            paramsNewstack['output'] = self.getExtraOutFile(tsId, suffix=ODD, ext=MRCS_EXT)
+            paramsNewstack['output'] = self.getExtraOutFile(tsId, suffix=ODD)
             Plugin.runImod(self, 'newstack', argsNewstack % paramsNewstack)
             paramsNewstack['input'] = evenFn
-            paramsNewstack['output'] = self.getExtraOutFile(tsId, suffix=EVEN, ext=MRCS_EXT)
+            paramsNewstack['output'] = self.getExtraOutFile(tsId, suffix=EVEN)
             Plugin.runImod(self, 'newstack', argsNewstack % paramsNewstack)
 
         output = self.getOutputSetOfTiltSeries(self.inputSetOfTiltSeries.get(), self.binning.get())
@@ -338,8 +338,8 @@ class ProtImodTsNormalization(ProtImodBase):
 
             newTi.setAcquisition(tiltImage.getAcquisition())
             if self.applyToOddEven(ts):
-                locationOdd = index + 1, self.getExtraOutFile(tsId, suffix=ODD, ext=MRCS_EXT)
-                locationEven = index + 1, self.getExtraOutFile(tsId, suffix=EVEN, ext=MRCS_EXT)
+                locationOdd = index + 1, self.getExtraOutFile(tsId, suffix=ODD)
+                locationEven = index + 1, self.getExtraOutFile(tsId, suffix=EVEN)
                 newTi.setOddEven([ih.locationToXmipp(locationOdd), ih.locationToXmipp(locationEven)])
             else:
                 newTi.setOddEven([])

--- a/imod/protocols/protocol_tsPreprocess.py
+++ b/imod/protocols/protocol_tsPreprocess.py
@@ -29,7 +29,7 @@ import pyworkflow.protocol.params as params
 from pwem.emlib.image import ImageHandler
 import tomo.objects as tomoObj
 from .. import Plugin
-from .protocol_base import ProtImodBase, OUTPUT_TILTSERIES_NAME, XF_EXT, ODD, EVEN, MRCS_EXT
+from .protocol_base import ProtImodBase, OUTPUT_TILTSERIES_NAME, XF_EXT, ODD, EVEN
 from ..utils import genXfFile
 
 

--- a/imod/protocols/protocol_xCorrPrealignment.py
+++ b/imod/protocols/protocol_xCorrPrealignment.py
@@ -24,7 +24,6 @@
 # *
 # *****************************************************************************
 
-import os
 import numpy as np
 
 from pyworkflow import BETA
@@ -125,7 +124,8 @@ class ProtImodXcorrPrealignment(ProtImodBase):
 
         trimming = form.addGroup('Trimming parameters', expertLevel=params.LEVEL_ADVANCED)
 
-        self.trimimgForm(trimming, pxTrimCondition='False', correlationCondition='True', levelType=params.LEVEL_ADVANCED)
+        self.trimimgForm(trimming, pxTrimCondition='False',
+                         correlationCondition='True', levelType=params.LEVEL_ADVANCED)
         self.filteringParametersForm(form, condition='True', levelType=params.LEVEL_ADVANCED)
 
     # -------------------------- INSERT steps functions -----------------------
@@ -134,7 +134,7 @@ class ProtImodXcorrPrealignment(ProtImodBase):
         for tsId in self.tsDict.keys():
             self._insertFunctionStep(self.convertInputStep, tsId)
             self._insertFunctionStep(self.computeXcorrStep, tsId)
-            self._insertFunctionStep(self.generateOutputStackStep,tsId)
+            self._insertFunctionStep(self.generateOutputStackStep, tsId)
             if self.computeAlignment.get() == 0:
                 self._insertFunctionStep(self.computeInterpolatedStackStep, tsId)
         self._insertFunctionStep(self.closeOutputSetsStep)

--- a/imod/protocols/protocol_xRaysEraser.py
+++ b/imod/protocols/protocol_xRaysEraser.py
@@ -244,10 +244,10 @@ class ProtImodXraysEraser(ProtImodBase):
             oddFn = firstItem.getOdd().split('@')[1]
             evenFn = firstItem.getEven().split('@')[1]
             paramsCcderaser['input'] = oddFn
-            paramsCcderaser['output'] = self.getExtraOutFile(tsId, suffix=ODD, ext=MRCS_EXT)
+            paramsCcderaser['output'] = self.getExtraOutFile(tsId, suffix=ODD)
             Plugin.runImod(self, 'ccderaser', argsCcderaser % paramsCcderaser)
             paramsCcderaser['input'] = evenFn
-            paramsCcderaser['output'] = self.getExtraOutFile(tsId, suffix=EVEN, ext=MRCS_EXT)
+            paramsCcderaser['output'] = self.getExtraOutFile(tsId, suffix=EVEN)
             Plugin.runImod(self, 'ccderaser', argsCcderaser % paramsCcderaser)
 
     def createOutputStep(self, tsId):
@@ -267,8 +267,8 @@ class ProtImodXraysEraser(ProtImodBase):
             newTi.setLocation(index + 1, self.getExtraOutFile(tsId))
 
             if self.applyToOddEven(ts):
-                locationOdd = index + 1, self.getExtraOutFile(tsId, suffix=ODD, ext=MRCS_EXT)
-                locationEven = index + 1, self.getExtraOutFile(tsId, suffix=EVEN, ext=MRCS_EXT)
+                locationOdd = index + 1, self.getExtraOutFile(tsId, suffix=ODD)
+                locationEven = index + 1, self.getExtraOutFile(tsId, suffix=EVEN)
                 newTi.setOddEven([ih.locationToXmipp(locationOdd), ih.locationToXmipp(locationEven)])
             else:
                 newTi.setOddEven([])

--- a/imod/protocols/protocol_xRaysEraser.py
+++ b/imod/protocols/protocol_xRaysEraser.py
@@ -24,8 +24,6 @@
 # *
 # *****************************************************************************
 
-import os
-
 from pyworkflow import BETA
 import pyworkflow.protocol.params as params
 from pyworkflow.object import Set
@@ -33,8 +31,8 @@ from pwem.emlib.image import ImageHandler
 import tomo.objects as tomoObj
 
 from .. import Plugin
-from .protocol_base import ProtImodBase, OUTPUT_TILTSERIES_NAME, EXT_MRCS_TS_ODD_NAME, EXT_MRCS_TS_EVEN_NAME, ODD, \
-    MRCS_EXT, EVEN, MOD_EXT
+from .protocol_base import (ProtImodBase, OUTPUT_TILTSERIES_NAME,
+                            ODD, EVEN, MOD_EXT)
 
 
 class ProtImodXraysEraser(ProtImodBase):

--- a/imod/tests/test_protocols_imod.py
+++ b/imod/tests/test_protocols_imod.py
@@ -670,7 +670,7 @@ class TestImodReconstructionWorkflow(TestImodBase):
         ih = ImageHandler()
         outputDimensions = ih.getDimensions(output.getFirstItem().getFirstItem().getFileName())
 
-        self.assertEqual(outputDimensions, (256, 256, 61, 1))
+        self.assertEqual(outputDimensions, (256, 256, 1, 61))
 
         # Sampling rate
         inSamplingRate = self.protTomoProjection.inputSetOfTomograms.get().getSamplingRate()

--- a/imod/tests/test_protocols_imod.py
+++ b/imod/tests/test_protocols_imod.py
@@ -460,7 +460,7 @@ class TestImodReconstructionWorkflow(TestImodBase):
         tsId = ts.getFirstItem().getTsId()
 
         self.assertTrue(os.path.exists(os.path.join(self.protDoseFilter._getExtraPath(tsId),
-                                                    tsId + ".mrc")))
+                                                    tsId + ".mrcs")))
 
     def test_xRaysEraserOutputTS(self):
 
@@ -470,7 +470,7 @@ class TestImodReconstructionWorkflow(TestImodBase):
         tsId = ts.getFirstItem().getTsId()
 
         self.assertTrue(os.path.exists(os.path.join(self.protXRaysEraser._getExtraPath(tsId),
-                                                    tsId + ".mrc")))
+                                                    tsId + ".mrcs")))
 
     def test_excludeViewsOutputTS(self):
 
@@ -480,7 +480,7 @@ class TestImodReconstructionWorkflow(TestImodBase):
         tsId = ts.getFirstItem().getTsId()
 
         self.assertTrue(os.path.exists(os.path.join(self.protExcludeViews._getExtraPath(tsId),
-                                                    tsId + ".mrc")))
+                                                    tsId + ".mrcs")))
 
         for index, tsOut in enumerate(ts):
             self.assertEqual(tsOut.getSize(), self.excludeViewsOutputSizes[tsOut.getTsId()])
@@ -493,7 +493,7 @@ class TestImodReconstructionWorkflow(TestImodBase):
         tsId = ts.getFirstItem().getTsId()
 
         self.assertTrue(os.path.exists(os.path.join(self.protTSNormalization._getExtraPath(tsId),
-                                                    tsId + ".mrc")))
+                                                    tsId + ".mrcs")))
 
         inSamplingRate = self.protTSNormalization.inputSetOfTiltSeries.get().getSamplingRate()
         outSamplingRate = ts.getSamplingRate()
@@ -507,7 +507,7 @@ class TestImodReconstructionWorkflow(TestImodBase):
 
         tsId = ts.getFirstItem().getTsId()
         outputLocation = os.path.join(self.protXcorr._getExtraPath(tsId),
-                                      tsId + ".mrc")
+                                      tsId + ".mrcs")
 
         self.assertTrue(os.path.exists(outputLocation))
 
@@ -521,7 +521,7 @@ class TestImodReconstructionWorkflow(TestImodBase):
 
         tsId = ts.getFirstItem().getTsId()
         outputLocation = os.path.join(self.protXcorr._getExtraPath(tsId),
-                                      tsId + ".mrc")
+                                      tsId + ".mrcs")
 
         self.assertTrue(os.path.exists(outputLocation))
 
@@ -552,7 +552,7 @@ class TestImodReconstructionWorkflow(TestImodBase):
 
         tsId = output.getFirstItem().getTsId()
         outputLocation = os.path.join(self.protFiducialAlignment._getExtraPath(tsId),
-                                      tsId + ".mrc")
+                                      tsId + ".mrcs")
 
         self.assertTrue(os.path.exists(outputLocation))
 
@@ -565,7 +565,7 @@ class TestImodReconstructionWorkflow(TestImodBase):
 
         tsId = output.getFirstItem().getTsId()
         outputLocation = os.path.join(self.protFiducialAlignment._getExtraPath(tsId),
-                                      tsId + ".mrc")
+                                      tsId + ".mrcs")
 
         self.assertTrue(os.path.exists(outputLocation))
 
@@ -608,7 +608,7 @@ class TestImodReconstructionWorkflow(TestImodBase):
 
         tsId = output.getFirstItem().getTsId()
         outputLocation = os.path.join(self.protApplyTransformationMatrix._getExtraPath(tsId),
-                                      tsId + ".mrc")
+                                      tsId + ".mrcs")
 
         self.assertTrue(os.path.exists(outputLocation))
 
@@ -765,7 +765,7 @@ class TestImodCTFCorrectionWorkflow(TestImodBase):
         for ts in output:
             tsId = ts.getTsId()
             outputLocation = os.path.join(self.protCTFCorrection._getExtraPath(tsId),
-                                          '%s.mrc' % tsId)
+                                          '%s.mrcs' % tsId)
 
             self.assertTrue(os.path.exists(outputLocation))
 


### PR DESCRIPTION
Fixed the issue with extensions discussed on Discord.
TO DO: implement cleanup of backup files (with `.mrc~` extension), will open an issue for that.