### PR TITLE
  - CTF correction: get rid of the decorator. Manage the failed TS in…

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -11,9 +11,12 @@
     * The xf, defocus, and tlt files are generated inside each TS extra sub-directory.
  Developers:
   - Update the acquisition order in the CTFTomo objects (field added to that class in scipion-em-tomo v3.7.0).
-  - Refactorization: avoid the excesive usage of getFirstItem.
+  - Refactorization: avoid the excessive usage of getFirstItem.
   - File generation methods (most of them in utils) adapted to the CTF-TS intersection functionality.
   - Fixing sorted dictionary in ctf correction. How to access the defocus list in utils.py
+  - CTF correction: get rid of the decorator. Manage the failed TS in the createOutputStep.
+  - Fix a bug in the base class for the generation of alignment files when there input TS are not aligned and there
+    aren't excluded views.
 3.3.0:
   - bugfix for import ctf, set missing defocus flag
   - move plugin-specific import CTF protocol to the core

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -17,6 +17,7 @@
   - CTF correction: get rid of the decorator. Manage the failed TS in the createOutputStep.
   - Fix a bug in the base class for the generation of alignment files when there input TS are not aligned and there
     aren't excluded views.
+  - Fix a bug in the generation of defocus files.
 3.3.0:
   - bugfix for import ctf, set missing defocus flag
   - move plugin-specific import CTF protocol to the core

--- a/imod/protocols/protocol_ctfCorrection.py
+++ b/imod/protocols/protocol_ctfCorrection.py
@@ -172,6 +172,7 @@ class ProtImodCtfCorrection(ProtImodBase):
             self._insertFunctionStep(self.convertInputsStep, tsId, presentAcqOrders)
             self._insertFunctionStep(self.ctfCorrection, tsId)
             self._insertFunctionStep(self.createOutputStep, tsId, presentAcqOrders)
+        self._insertFunctionStep(self.closeOutputSetsStep)
 
     # --------------------------- STEPS functions -----------------------------
     def _initialize(self):
@@ -184,8 +185,9 @@ class ProtImodCtfCorrection(ProtImodBase):
         allTsIds = set(tsIds + ctfTsIds)
         nonMatchingTsIds = [tsId for tsId in allTsIds if tsId not in self.presentTsIds]
         # Update the msg for each protocol execution to avoid duplicities in the summary
-        self.matchingMsg.set(f'WARNING! No CTFTomoSeries found for the tilt-series: {nonMatchingTsIds}')
-        self._store(self.matchingMsg)
+        if nonMatchingTsIds:
+            self.matchingMsg.set(f'WARNING! No CTFTomoSeries found for the tilt-series: {nonMatchingTsIds}')
+            self._store(self.matchingMsg)
 
     def convertInputsStep(self, tsId, presentAcqOrders):
         # Generate the alignment-related files: xf, tlt, and a possible mrc

--- a/imod/protocols/protocol_fiducialModel.py
+++ b/imod/protocols/protocol_fiducialModel.py
@@ -540,10 +540,7 @@ class ProtImodFiducialModel(ProtImodBase):
         extraPrefix = self._getExtraPath(tsId)
 
         firstItem = ts.getFirstItem()
-        trackFilePath = os.path.join(extraPrefix,
-                                     firstItem.parseFileName(suffix="_track",
-                                                             extension=".com"))
-
+        trackFilePath = os.path.join(extraPrefix, tsId + '_track.com')
         template = """# Command file for running BEADTRACK
 #
 ####CreatedVersion####4.9.12

--- a/imod/utils.py
+++ b/imod/utils.py
@@ -632,15 +632,14 @@ def generateDefocusIMODFileFromObject(ctfTomoSeries, defocusFilePath,
     if ctfTomoSeries.getFirstItem().hasEstimationInfoAsList() and not isRelion:
 
         logger.debug("Defocus file generated form a list.")
-
         flag = ctfTomoSeries.getIMODDefocusFileFlag()
+        nEstimationsInRange = ctfTomoSeries.getNumberOfEstimationsInRange()
 
         if flag == 0:
             # Plain estimation
 
             logger.debug("Flag 0: Plain estimation.")
             defocusUDict = generateDefocusUDictionary(ctfTomoSeries)
-            nEstimationsInRange = ctfTomoSeries.getNumberOfEstimationsInRange()
 
             # Write IMOD defocus file
             with open(defocusFilePath, 'w') as f:
@@ -656,11 +655,11 @@ def generateDefocusIMODFileFromObject(ctfTomoSeries, defocusFilePath,
                     # the tilt-image with the highest negative angle)
                     newLine = (pattern % (
                         index,
-                        index + ctfTomoSeries.getNumberOfEstimationsInRange(),
-                        round(tiltSeries[index + ctfTomoSeries.getNumberOfEstimationsInRange()].getTiltAngle(), 2),
+                        index + nEstimationsInRange,
                         round(tiltSeries[index].getTiltAngle(), 2),
+                        round(tiltSeries[index + nEstimationsInRange].getTiltAngle(), 2),
                         # CONVERT DEFOCUS VALUE TO NANOMETERS (IMOD CONVENTION)
-                        int(float(defocusUDict[index][0]) / 10)
+                        int(float(defocusUDict[index + nEstimationsInRange][0]) / 10)
                     ))
 
                     lines.append(newLine)
@@ -687,7 +686,7 @@ def generateDefocusIMODFileFromObject(ctfTomoSeries, defocusFilePath,
 
                 for index in sorted(defocusUDict.keys()):
 
-                    if index + ctfTomoSeries.getNumberOfEstimationsInRange() > len(defocusUDict.keys()):
+                    if index + nEstimationsInRange > len(defocusUDict.keys()):
                         break
 
                     # Dictionary keys is reversed because IMOD set indexes
@@ -695,14 +694,14 @@ def generateDefocusIMODFileFromObject(ctfTomoSeries, defocusFilePath,
                     # the tilt-image with the highest negative angle)
                     newLine = ("%d\t%d\t%.2f\t%.2f\t%.1f\t%.1f\t%.2f\n" % (
                         index,
-                        index + ctfTomoSeries.getNumberOfEstimationsInRange(),
-                        round(tiltSeries[index + ctfTomoSeries.getNumberOfEstimationsInRange()].getTiltAngle(), 2),
+                        index + nEstimationsInRange,
                         round(tiltSeries[index].getTiltAngle(), 2),
+                        round(tiltSeries[index + nEstimationsInRange].getTiltAngle(), 2),
                         # CONVERT DEFOCUS VALUE TO NANOMETERS (IMOD CONVENTION)
-                        float(defocusUDict[index][0]) / 10,
+                        float(defocusUDict[index + nEstimationsInRange][0]) / 10,
                         # CONVERT DEFOCUS VALUE TO NANOMETERS (IMOD CONVENTION)
-                        float(defocusVDict[index][0]) / 10,
-                        float(defocusAngleDict[index][0]),
+                        float(defocusVDict[index + nEstimationsInRange][0]) / 10,
+                        float(defocusAngleDict[index + nEstimationsInRange][0]),
                     ))
 
                     lines.append(newLine)
@@ -723,7 +722,7 @@ def generateDefocusIMODFileFromObject(ctfTomoSeries, defocusFilePath,
 
                 for index in sorted(defocusUDict.keys()):
 
-                    if index + ctfTomoSeries.getNumberOfEstimationsInRange() > len(defocusUDict.keys()):
+                    if index + nEstimationsInRange > len(defocusUDict.keys()):
                         break
 
                     # Dictionary keys is reversed because IMOD set indexes
@@ -731,12 +730,12 @@ def generateDefocusIMODFileFromObject(ctfTomoSeries, defocusFilePath,
                     # the tilt-image with the highest negative angle)
                     newLine = ("%d\t%d\t%.2f\t%.2f\t%.1f\t%.2f\n" % (
                         index,
-                        index + ctfTomoSeries.getNumberOfEstimationsInRange(),
-                        round(tiltSeries[index + ctfTomoSeries.getNumberOfEstimationsInRange()].getTiltAngle(), 2),
+                        index + nEstimationsInRange,
                         round(tiltSeries[index].getTiltAngle(), 2),
+                        round(tiltSeries[index + nEstimationsInRange].getTiltAngle(), 2),
                         # CONVERT DEFOCUS VALUE TO NANOMETERS (IMOD CONVENTION)
-                        float(defocusUDict[index][0]) / 10,
-                        float(phaseShiftDict[index][0]),
+                        float(defocusUDict[index + nEstimationsInRange][0]) / 10,
+                        float(phaseShiftDict[index + nEstimationsInRange][0]),
                     ))
 
                     lines.append(newLine)
@@ -760,7 +759,7 @@ def generateDefocusIMODFileFromObject(ctfTomoSeries, defocusFilePath,
 
                 for index in sorted(defocusUDict.keys()):
 
-                    if index + ctfTomoSeries.getNumberOfEstimationsInRange() > len(defocusUDict.keys()):
+                    if index + nEstimationsInRange > len(defocusUDict.keys()):
                         break
 
                     # Dictionary keys is reversed because IMOD set indexes
@@ -768,15 +767,15 @@ def generateDefocusIMODFileFromObject(ctfTomoSeries, defocusFilePath,
                     # the tilt-image with the highest negative angle)
                     newLine = ("%d\t%d\t%.2f\t%.2f\t%.1f\t%.1f\t%.2f\t%.2f\n" % (
                         index,
-                        index + ctfTomoSeries.getNumberOfEstimationsInRange(),
-                        round(tiltSeries[index + ctfTomoSeries.getNumberOfEstimationsInRange()].getTiltAngle(), 2),
+                        index + nEstimationsInRange,
                         round(tiltSeries[index].getTiltAngle(), 2),
+                        round(tiltSeries[index + nEstimationsInRange].getTiltAngle(), 2),
                         # CONVERT DEFOCUS VALUE TO NANOMETERS (IMOD CONVENTION)
-                        float(defocusUDict[index][0]) / 10,
+                        float(defocusUDict[index + nEstimationsInRange][0]) / 10,
                         # CONVERT DEFOCUS VALUE TO NANOMETERS (IMOD CONVENTION)
-                        float(defocusVDict[index][0]) / 10,
-                        float(defocusAngleDict[index][0]),
-                        float(phaseShiftDict[index][0])
+                        float(defocusVDict[index + nEstimationsInRange][0]) / 10,
+                        float(defocusAngleDict[index + nEstimationsInRange][0]),
+                        float(phaseShiftDict[index + nEstimationsInRange][0])
                     ))
 
                     lines.append(newLine)
@@ -800,7 +799,7 @@ def generateDefocusIMODFileFromObject(ctfTomoSeries, defocusFilePath,
 
                 for index in sorted(defocusUDict.keys()):
 
-                    if index + ctfTomoSeries.getNumberOfEstimationsInRange() > len(defocusUDict.keys()):
+                    if index + nEstimationsInRange > len(defocusUDict.keys()):
                         break
 
                     # Dictionary keys is reversed because IMOD set indexes
@@ -808,16 +807,16 @@ def generateDefocusIMODFileFromObject(ctfTomoSeries, defocusFilePath,
                     # the tilt-image with the highest negative angle)
                     newLine = ("%d\t%d\t%.2f\t%.2f\t%.1f\t%.1f\t%.2f\t%.2f\t%.4f\n" % (
                         index,
-                        index + ctfTomoSeries.getNumberOfEstimationsInRange(),
-                        round(tiltSeries[index + ctfTomoSeries.getNumberOfEstimationsInRange()].getTiltAngle(), 2),
+                        index + nEstimationsInRange,
                         round(tiltSeries[index].getTiltAngle(), 2),
+                        round(tiltSeries[index + nEstimationsInRange].getTiltAngle(), 2),
                         # CONVERT DEFOCUS VALUE TO NANOMETERS (IMOD CONVENTION)
-                        float(defocusUDict[index][0]) / 10,
+                        float(defocusUDict[index + nEstimationsInRange][0]) / 10,
                         # CONVERT DEFOCUS VALUE TO NANOMETERS (IMOD CONVENTION)
-                        float(defocusVDict[index][0]) / 10,
-                        float(defocusAngleDict[index][0]),
-                        float(phaseShiftDict[index][0]),
-                        float(cutOnFreqDict[index][0])
+                        float(defocusVDict[index + nEstimationsInRange][0]) / 10,
+                        float(defocusAngleDict[index + nEstimationsInRange][0]),
+                        float(phaseShiftDict[index + nEstimationsInRange][0]),
+                        float(cutOnFreqDict[index + nEstimationsInRange][0])
                     ))
 
                     lines.append(newLine)


### PR DESCRIPTION
… the createOutputStep.

  - Fix a bug in the base class for the generation of alignment files when there input TS are not aligned and there aren't excluded views.