### PR TITLE
Fixed bug that prevented etomo from opening when TS had excluded views created with Tomo viewer subset

### DIFF
--- a/imod/protocols/protocol_etomo.py
+++ b/imod/protocols/protocol_etomo.py
@@ -178,7 +178,7 @@ class ProtImodEtomo(ProtImodBase):
         args += f'-binning 1.0 -Cs {acq.getSphericalAberration()} -voltage {int(acq.getVoltage())} '
 
         if ts.getExcludedViewsIndex():
-            args += f'-ViewsToSkip {",".join(ts.getExcludedViewsIndex())} '
+            args += f'-ViewsToSkip {",".join(map(str,ts.getExcludedViewsIndex()))} '
 
         Plugin.runImod(self, 'copytomocoms', args, cwd=extraPrefix)
 


### PR DESCRIPTION
Followed suggestion from @pconesa on Discord