### PR TITLE
close #271

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+3.6.1:
+ Users:
+  - bugfix for o/e tomo reconstruction, see #271
 3.6.0:
  Users:
   - fix default params (close check default values #281 )

--- a/imod/__init__.py
+++ b/imod/__init__.py
@@ -37,7 +37,7 @@ import pwem
 from imod.constants import (IMOD_HOME, ETOMO_CMD, DEFAULT_VERSION,
                             VERSIONS, IMOD_VIEWER_BINNING)
 
-__version__ = '3.6'
+__version__ = '3.6.1'
 _logo = "icon.png"
 _references = ['Kremer1996', 'Mastronarde2017']
 

--- a/imod/protocols/protocol_tomoReconstruction.py
+++ b/imod/protocols/protocol_tomoReconstruction.py
@@ -322,7 +322,7 @@ class ProtImodTomoReconstruction(ProtImodBase):
             if self.oddEvenFlag:
                 # Odd
                 paramsTilt['-InputProjections'] = self.getTmpOutFile(tsId, suffix=ODD)
-                oddEvenTmp[0] = self.getExtraOutFile(tsId, suffix=ODD, ext=MRC_EXT)
+                oddEvenTmp[0] = self.getTmpOutFile(tsId, suffix=ODD, ext=MRC_EXT)
                 paramsTilt['-OutputFile'] = oddEvenTmp[0]
                 self.runProgram('tilt', paramsTilt)
 
@@ -332,7 +332,7 @@ class ProtImodTomoReconstruction(ProtImodBase):
 
                 # Even
                 paramsTilt['-InputProjections'] = self.getTmpOutFile(tsId, suffix=EVEN)
-                oddEvenTmp[1] = self.getExtraOutFile(tsId, suffix=EVEN, ext=MRC_EXT)
+                oddEvenTmp[1] = self.getTmpOutFile(tsId, suffix=EVEN, ext=MRC_EXT)
                 paramsTilt['-OutputFile'] = oddEvenTmp[1]
                 self.runProgram('tilt', paramsTilt)
 


### PR DESCRIPTION
Odd/even tilt mrc reconstructions go to tmp and after trimvol they are in extra as expected.