### PR TITLE
Checking for the correct original filename in etomo protocol

### DIFF
--- a/imod/protocols/protocol_etomo.py
+++ b/imod/protocols/protocol_etomo.py
@@ -311,7 +311,7 @@ class ProtImodEtomo(ProtImodBase):
                 outputAliTs.update(newTs)
 
             """Original tilt-series with alignment information"""
-            inFilePath = self.getExtraOutFile(tsId, suffix="orig", ext=MRC_EXT)
+            inFilePath = self.getExtraOutFile(tsId, ext=MRC_EXT)
             # input TS were renamed by etomo when "using fixed stack"
             if os.path.exists(inFilePath):
 


### PR DESCRIPTION
File with orig suffix does not exist, thus the TS with alignment metadata is never created