### PR TITLE
Invert defocus handedness ctfphaseflip

### DIFF
--- a/imod/protocols/protocol_ctfCorrection.py
+++ b/imod/protocols/protocol_ctfCorrection.py
@@ -147,6 +147,13 @@ class ProtImodCtfCorrection(ProtImodBase):
                            "entering the negative of the desired spacing, "
                            "which disables the scaling of the spacing.")
 
+        form.addParam('invertDefocus',
+                      params.BooleanParam,
+                      label='Invert defocus gradient?',
+                      default=False,
+                      important=True,
+                      help="Invert the tilt angles for defocus calculation. Should only be used if you know that the defocus gradient is inverted with the current tilt axis angle.")
+
         form.addHidden(params.USE_GPU,
                        params.BooleanParam,
                        default=True,
@@ -221,6 +228,9 @@ class ProtImodCtfCorrection(ProtImodBase):
                 "-AmplitudeContrast": self.acq.getAmplitudeContrast(),
                 "-InterpolationWidth": self.interpolationWidth.get()
             }
+
+            if self.invertDefocus:
+                 paramsCtfPhaseFlip["-InvertTiltAngles"] = ''
 
             if self.usesGpu():
                 paramsCtfPhaseFlip["-UseGPU"] = self.getGpuList()[0]

--- a/imod/protocols/protocol_ctfCorrection.py
+++ b/imod/protocols/protocol_ctfCorrection.py
@@ -152,7 +152,7 @@ class ProtImodCtfCorrection(ProtImodBase):
                       label='Invert defocus gradient?',
                       default=False,
                       important=True,
-                      help="Invert the tilt angles for defocus calculation. Should only be used if you know that the defocus gradient is inverted with the current tilt axis angle.")
+                      help="Invert the tilt angles for defocus calculation. Should only be used if you know that the defocus gradient is inverted with the current tilt axis angle. The default convention in IMOD corresponds to -1 defocus sign in RELION.See IMOD ctfplotter documentation for details.")
 
         form.addHidden(params.USE_GPU,
                        params.BooleanParam,

--- a/imod/utils.py
+++ b/imod/utils.py
@@ -616,7 +616,7 @@ def refactorCTFDefocusAstigmatismPhaseShiftCutOnFreqEstimationInfo(ctfInfoIMODTa
 
 
 def generateDefocusIMODFileFromObject(ctfTomoSeries, defocusFilePath,
-                                      isRelion=False, inputTiltSeries=None, presentAcqOrders=None):
+                                      isRelion=False, inputTiltSeries=None, presentAcqOrders=None, invertTiltAngles=False):
     """ This method takes a ctfTomoSeries object a generate a
     defocus information file in IMOD formatting containing
     the same information in the specified location. """
@@ -625,6 +625,11 @@ def generateDefocusIMODFileFromObject(ctfTomoSeries, defocusFilePath,
         tiltSeries = ctfTomoSeries.getTiltSeries()
     else:
         tiltSeries = inputTiltSeries
+
+    if invertTiltAngles:
+        invert_factor = -1
+    else:
+        invert_factor = 1
 
     logger.info("Trying to generate defocus file at %s" % defocusFilePath)
 
@@ -656,8 +661,8 @@ def generateDefocusIMODFileFromObject(ctfTomoSeries, defocusFilePath,
                     newLine = (pattern % (
                         index,
                         index + nEstimationsInRange,
-                        round(tiltSeries[index].getTiltAngle(), 2),
-                        round(tiltSeries[index + nEstimationsInRange].getTiltAngle(), 2),
+                        round(tiltSeries[index].getTiltAngle() * invert_factor, 2),
+                        round(tiltSeries[index + nEstimationsInRange].getTiltAngle() * invert_factor, 2),
                         # CONVERT DEFOCUS VALUE TO NANOMETERS (IMOD CONVENTION)
                         int(float(defocusUDict[index + nEstimationsInRange][0]) / 10)
                     ))
@@ -695,8 +700,8 @@ def generateDefocusIMODFileFromObject(ctfTomoSeries, defocusFilePath,
                     newLine = ("%d\t%d\t%.2f\t%.2f\t%.1f\t%.1f\t%.2f\n" % (
                         index,
                         index + nEstimationsInRange,
-                        round(tiltSeries[index].getTiltAngle(), 2),
-                        round(tiltSeries[index + nEstimationsInRange].getTiltAngle(), 2),
+                        round(tiltSeries[index].getTiltAngle() * invert_factor, 2),
+                        round(tiltSeries[index + nEstimationsInRange].getTiltAngle() * invert_factor, 2),
                         # CONVERT DEFOCUS VALUE TO NANOMETERS (IMOD CONVENTION)
                         float(defocusUDict[index + nEstimationsInRange][0]) / 10,
                         # CONVERT DEFOCUS VALUE TO NANOMETERS (IMOD CONVENTION)
@@ -731,8 +736,8 @@ def generateDefocusIMODFileFromObject(ctfTomoSeries, defocusFilePath,
                     newLine = ("%d\t%d\t%.2f\t%.2f\t%.1f\t%.2f\n" % (
                         index,
                         index + nEstimationsInRange,
-                        round(tiltSeries[index].getTiltAngle(), 2),
-                        round(tiltSeries[index + nEstimationsInRange].getTiltAngle(), 2),
+                        round(tiltSeries[index].getTiltAngle() * invert_factor, 2),
+                        round(tiltSeries[index + nEstimationsInRange].getTiltAngle() * invert_factor, 2),
                         # CONVERT DEFOCUS VALUE TO NANOMETERS (IMOD CONVENTION)
                         float(defocusUDict[index + nEstimationsInRange][0]) / 10,
                         float(phaseShiftDict[index + nEstimationsInRange][0]),
@@ -768,8 +773,8 @@ def generateDefocusIMODFileFromObject(ctfTomoSeries, defocusFilePath,
                     newLine = ("%d\t%d\t%.2f\t%.2f\t%.1f\t%.1f\t%.2f\t%.2f\n" % (
                         index,
                         index + nEstimationsInRange,
-                        round(tiltSeries[index].getTiltAngle(), 2),
-                        round(tiltSeries[index + nEstimationsInRange].getTiltAngle(), 2),
+                        round(tiltSeries[index].getTiltAngle() * invert_factor, 2),
+                        round(tiltSeries[index + nEstimationsInRange].getTiltAngle() * invert_factor, 2),
                         # CONVERT DEFOCUS VALUE TO NANOMETERS (IMOD CONVENTION)
                         float(defocusUDict[index + nEstimationsInRange][0]) / 10,
                         # CONVERT DEFOCUS VALUE TO NANOMETERS (IMOD CONVENTION)
@@ -808,8 +813,8 @@ def generateDefocusIMODFileFromObject(ctfTomoSeries, defocusFilePath,
                     newLine = ("%d\t%d\t%.2f\t%.2f\t%.1f\t%.1f\t%.2f\t%.2f\t%.4f\n" % (
                         index,
                         index + nEstimationsInRange,
-                        round(tiltSeries[index].getTiltAngle(), 2),
-                        round(tiltSeries[index + nEstimationsInRange].getTiltAngle(), 2),
+                        round(tiltSeries[index].getTiltAngle() * invert_factor, 2),
+                        round(tiltSeries[index + nEstimationsInRange].getTiltAngle() * invert_factor, 2),
                         # CONVERT DEFOCUS VALUE TO NANOMETERS (IMOD CONVENTION)
                         float(defocusUDict[index + nEstimationsInRange][0]) / 10,
                         # CONVERT DEFOCUS VALUE TO NANOMETERS (IMOD CONVENTION)
@@ -844,8 +849,8 @@ def generateDefocusIMODFileFromObject(ctfTomoSeries, defocusFilePath,
                     newLine = ("%d\t%d\t%.2f\t%.2f\t%.1f\t%.1f\t%.2f\n" % (
                         ind,
                         ind,
-                        tiltAngle,
-                        tiltAngle,
+                        tiltAngle * invert_factor,
+                        tiltAngle * invert_factor,
                         # CONVERT DEFOCUS VALUE TO NANOMETERS (IMOD CONVENTION)
                         ctfTomo.getDefocusU() / 10,
                         # CONVERT DEFOCUS VALUE TO NANOMETERS (IMOD CONVENTION)

--- a/imod/utils.py
+++ b/imod/utils.py
@@ -146,7 +146,7 @@ def formatFiducialResidList(fiducialFilePath):
     file path and returns a list containing the coordinates
     and residual values of each fiducial for each tilt-image
     belonging to the tilt-series. Since IMOD establishes a
-    float value for each coordinate the are parsed to int. """
+    float value for each coordinate they are parsed to int. """
 
     fiducialResidList = []
 
@@ -616,7 +616,7 @@ def refactorCTFDefocusAstigmatismPhaseShiftCutOnFreqEstimationInfo(ctfInfoIMODTa
 
 
 def generateDefocusIMODFileFromObject(ctfTomoSeries, defocusFilePath,
-                                      isRelion=False, inputTiltSeries=None, presentAcqOrders=None, invertTiltAngles=False):
+                                      isRelion=False, inputTiltSeries=None, presentAcqOrders=None):
     """ This method takes a ctfTomoSeries object a generate a
     defocus information file in IMOD formatting containing
     the same information in the specified location. """
@@ -625,11 +625,6 @@ def generateDefocusIMODFileFromObject(ctfTomoSeries, defocusFilePath,
         tiltSeries = ctfTomoSeries.getTiltSeries()
     else:
         tiltSeries = inputTiltSeries
-
-    if invertTiltAngles:
-        invert_factor = -1
-    else:
-        invert_factor = 1
 
     logger.info("Trying to generate defocus file at %s" % defocusFilePath)
 
@@ -661,8 +656,8 @@ def generateDefocusIMODFileFromObject(ctfTomoSeries, defocusFilePath,
                     newLine = (pattern % (
                         index,
                         index + nEstimationsInRange,
-                        round(tiltSeries[index].getTiltAngle() * invert_factor, 2),
-                        round(tiltSeries[index + nEstimationsInRange].getTiltAngle() * invert_factor, 2),
+                        round(tiltSeries[index].getTiltAngle(), 2),
+                        round(tiltSeries[index + nEstimationsInRange].getTiltAngle(), 2),
                         # CONVERT DEFOCUS VALUE TO NANOMETERS (IMOD CONVENTION)
                         int(float(defocusUDict[index + nEstimationsInRange][0]) / 10)
                     ))
@@ -700,8 +695,8 @@ def generateDefocusIMODFileFromObject(ctfTomoSeries, defocusFilePath,
                     newLine = ("%d\t%d\t%.2f\t%.2f\t%.1f\t%.1f\t%.2f\n" % (
                         index,
                         index + nEstimationsInRange,
-                        round(tiltSeries[index].getTiltAngle() * invert_factor, 2),
-                        round(tiltSeries[index + nEstimationsInRange].getTiltAngle() * invert_factor, 2),
+                        round(tiltSeries[index].getTiltAngle(), 2),
+                        round(tiltSeries[index + nEstimationsInRange].getTiltAngle(), 2),
                         # CONVERT DEFOCUS VALUE TO NANOMETERS (IMOD CONVENTION)
                         float(defocusUDict[index + nEstimationsInRange][0]) / 10,
                         # CONVERT DEFOCUS VALUE TO NANOMETERS (IMOD CONVENTION)
@@ -736,8 +731,8 @@ def generateDefocusIMODFileFromObject(ctfTomoSeries, defocusFilePath,
                     newLine = ("%d\t%d\t%.2f\t%.2f\t%.1f\t%.2f\n" % (
                         index,
                         index + nEstimationsInRange,
-                        round(tiltSeries[index].getTiltAngle() * invert_factor, 2),
-                        round(tiltSeries[index + nEstimationsInRange].getTiltAngle() * invert_factor, 2),
+                        round(tiltSeries[index].getTiltAngle(), 2),
+                        round(tiltSeries[index + nEstimationsInRange].getTiltAngle(), 2),
                         # CONVERT DEFOCUS VALUE TO NANOMETERS (IMOD CONVENTION)
                         float(defocusUDict[index + nEstimationsInRange][0]) / 10,
                         float(phaseShiftDict[index + nEstimationsInRange][0]),
@@ -773,8 +768,8 @@ def generateDefocusIMODFileFromObject(ctfTomoSeries, defocusFilePath,
                     newLine = ("%d\t%d\t%.2f\t%.2f\t%.1f\t%.1f\t%.2f\t%.2f\n" % (
                         index,
                         index + nEstimationsInRange,
-                        round(tiltSeries[index].getTiltAngle() * invert_factor, 2),
-                        round(tiltSeries[index + nEstimationsInRange].getTiltAngle() * invert_factor, 2),
+                        round(tiltSeries[index].getTiltAngle(), 2),
+                        round(tiltSeries[index + nEstimationsInRange].getTiltAngle(), 2),
                         # CONVERT DEFOCUS VALUE TO NANOMETERS (IMOD CONVENTION)
                         float(defocusUDict[index + nEstimationsInRange][0]) / 10,
                         # CONVERT DEFOCUS VALUE TO NANOMETERS (IMOD CONVENTION)
@@ -813,8 +808,8 @@ def generateDefocusIMODFileFromObject(ctfTomoSeries, defocusFilePath,
                     newLine = ("%d\t%d\t%.2f\t%.2f\t%.1f\t%.1f\t%.2f\t%.2f\t%.4f\n" % (
                         index,
                         index + nEstimationsInRange,
-                        round(tiltSeries[index].getTiltAngle() * invert_factor, 2),
-                        round(tiltSeries[index + nEstimationsInRange].getTiltAngle() * invert_factor, 2),
+                        round(tiltSeries[index].getTiltAngle(), 2),
+                        round(tiltSeries[index + nEstimationsInRange].getTiltAngle(), 2),
                         # CONVERT DEFOCUS VALUE TO NANOMETERS (IMOD CONVENTION)
                         float(defocusUDict[index + nEstimationsInRange][0]) / 10,
                         # CONVERT DEFOCUS VALUE TO NANOMETERS (IMOD CONVENTION)
@@ -849,8 +844,8 @@ def generateDefocusIMODFileFromObject(ctfTomoSeries, defocusFilePath,
                     newLine = ("%d\t%d\t%.2f\t%.2f\t%.1f\t%.1f\t%.2f\n" % (
                         ind,
                         ind,
-                        tiltAngle * invert_factor,
-                        tiltAngle * invert_factor,
+                        tiltAngle,
+                        tiltAngle,
                         # CONVERT DEFOCUS VALUE TO NANOMETERS (IMOD CONVENTION)
                         ctfTomo.getDefocusU() / 10,
                         # CONVERT DEFOCUS VALUE TO NANOMETERS (IMOD CONVENTION)


### PR DESCRIPTION
Added an option to the ctfphaseflip protocol that allows reversing the defocus gradient (analogous to IMOD -1 and +1 convention).