### PR TITLE
Invert defocus handedness in IMOD defocus files

### DIFF
--- a/imod/utils.py
+++ b/imod/utils.py
@@ -637,6 +637,8 @@ def generateDefocusIMODFileFromObject(ctfTomoSeries, defocusFilePath,
             tilt.setTiltAngle(-1 * tilt.getTiltAngle())
             newTS.append(tilt)
             newTS.write()
+        
+        tiltSeries = newTS
 
     logger.info("Trying to generate defocus file at %s" % defocusFilePath)
 


### PR DESCRIPTION
Hi,

I added the option `invertTiltAngles=False` in generateDefocusIMODFileFromObject() to make it possible to generate IMOD defocus files with inverted tilt angles, thus reversing the direction of the defocus within the tomogram _without_ inverting its physical hand. This is analogous to the -1/+1 convention for the defocus hand in RELION.

The motivation for this change is to be able to reconstruct NovaCTF tomograms with reversed defocus gradient. I will submit a PR to scipion-em-novactf that depends on this one. 

I am not sure if my implementation is good, I had to write a "dummy" TS sqlite in order to make persistent changes to the tilt angles, as discussed with @pconesa on Discord. Feedback is very much appreciated 🙂 

Thank you